### PR TITLE
Testing and stability patches

### DIFF
--- a/package/phylogenize/R/calc-phenotypes.R
+++ b/package/phylogenize/R/calc-phenotypes.R
@@ -142,8 +142,59 @@ calculate_phenotypes <- function(abd.meta, pz.db, ..., .opts=NULL) {
         } else if (opts('which_phenotype') == "specificity") {
 	    pz.message("  .....Running specificity")
             if (opts('prior_type') == "file") {
-                prior.data <- read.table(file.path(opts('input_dir'),
-                                                   opts('prior_file')))
+                prior_file <- opts('prior_file')
+                if (prior_file == "") {
+                    pz.error("prior_file must be set when prior_type is 'file'",
+                             .opts=opts)
+                }
+                prior_path <- if (file.exists(prior_file)) {
+                    prior_file
+                } else {
+                    file.path(opts('working_dir'), prior_file)
+                }
+                if (!(file.exists(prior_path))) {
+                    pz.error(paste0("Prior file not found: ", prior_path),
+                             .opts=opts)
+                }
+                if (grepl("\\.csv$", prior_path, ignore.case=TRUE)) {
+                    prior.data <- readr::read_csv(prior_path,
+                                                  show_col_types=FALSE)
+                } else {
+                    prior.data <- readr::read_tsv(prior_path,
+                                                  show_col_types=FALSE)
+                }
+                required_prior_columns <- c("env", "prior")
+                missing_prior_columns <- setdiff(required_prior_columns,
+                                                 names(prior.data))
+                if (length(missing_prior_columns) > 0) {
+                    pz.error(paste0(
+                        "Prior file is missing required column(s): ",
+                        paste(missing_prior_columns, collapse=", ")
+                    ), .opts=opts)
+                }
+                prior_envs <- trimws(as.character(prior.data[["env"]]))
+                if (any(is.na(prior_envs)) || any(prior_envs == "")) {
+                    pz.error("Prior file contains blank or missing environments",
+                             .opts=opts)
+                }
+                if (any(duplicated(prior_envs))) {
+                    duplicate_envs <- unique(prior_envs[duplicated(prior_envs)])
+                    pz.error(paste0(
+                        "Prior file contains duplicate environments: ",
+                        paste(duplicate_envs, collapse=", ")
+                    ), .opts=opts)
+                }
+                prior_values <- suppressWarnings(as.numeric(prior.data[["prior"]]))
+                if (any(is.na(prior_values))) {
+                    pz.error("Prior file contains nonnumeric prior values",
+                             .opts=opts)
+                }
+                if (any(!is.finite(prior_values)) || any(prior_values <= 0)) {
+                    pz.error("Prior file priors must be finite and greater than zero",
+                             .opts=opts)
+                }
+                prior.data[["env"]] <- prior_envs
+                prior.data[["prior"]] <- prior_values
             } else {
                 prior.data <- NULL
             }

--- a/package/phylogenize/R/calc-phenotypes.R
+++ b/package/phylogenize/R/calc-phenotypes.R
@@ -155,7 +155,12 @@ calculate_phenotypes <- function(abd.meta, pz.db, ..., .opts=NULL) {
             phenoP <- ess$phenoP
         } else if (opts("which_phenotype") == "provided") {
             pz.message("  .....Reading provided phenotype")
-            p_tbl <- readr::read_tsv(opts("phenotype_file"), show_col_types = FALSE)
+            phenotype_file <- opts("phenotype_file")
+            if (!(file.exists(phenotype_file))) {
+                pz.error(paste0("Phenotype file not found: ", phenotype_file),
+                         .opts=opts)
+            }
+            p_tbl <- readr::read_tsv(phenotype_file, show_col_types = FALSE)
             pz.message(paste0(
                 "  ..........Provided phenotype table has ",
                 nrow(p_tbl),
@@ -163,14 +168,74 @@ calculate_phenotypes <- function(abd.meta, pz.db, ..., .opts=NULL) {
                 ncol(p_tbl),
                 " column(s)"
             ))
+            if (nrow(p_tbl) == 0 || ncol(p_tbl) < 2) {
+                pz.error(paste0(
+                    "Provided phenotype table must have at least one row and ",
+                    "two columns"
+                ), .opts=opts)
+            }
+            phenotype_ids <- trimws(as.character(p_tbl[[1]]))
+            if (any(is.na(phenotype_ids)) || any(phenotype_ids == "")) {
+                pz.error("Provided phenotype table contains blank or missing taxon IDs",
+                         .opts=opts)
+            }
+            if (any(duplicated(phenotype_ids))) {
+                duplicate_ids <- unique(phenotype_ids[duplicated(phenotype_ids)])
+                pz.error(paste0(
+                    "Provided phenotype table contains duplicate taxon IDs: ",
+                    paste(duplicate_ids, collapse=", ")
+                ), .opts=opts)
+            }
             if (ncol(p_tbl) == 2) { # assume we only have species IDs and values
-                phenotype <- tibble::deframe(p_tbl)
+                phenotype_values <- suppressWarnings(as.numeric(p_tbl[[2]]))
+                if (any(is.na(phenotype_values))) {
+                    pz.error(
+                        "Provided phenotype table contains nonnumeric phenotype values",
+                        .opts=opts)
+                }
+                if (any(!is.finite(phenotype_values))) {
+                    pz.error(
+                        "Provided phenotype table contains non-finite phenotype values",
+                        .opts=opts)
+                }
+                names(phenotype_values) <- phenotype_ids
+                phenotype <- phenotype_values
             } else { # perform shrinkage on the provided values w/ their stderrs
+                required_pheno_columns <- c("estimate", "stderr")
+                missing_pheno_columns <- setdiff(required_pheno_columns,
+                                                 names(p_tbl))
+                if (length(missing_pheno_columns) > 0) {
+                    pz.error(paste0(
+                        "Provided phenotype table is missing required column(s): ",
+                        paste(missing_pheno_columns, collapse=", ")
+                    ), .opts=opts)
+                }
                 pz.message("  ..........Running shrinkage on provided phenotype")
-                p_est <- as.numeric(p_tbl[["estimate"]])
-                p_se <- as.numeric(p_tbl[["stderr"]])
-                names(p_est) <- p_tbl[[1]]
-                names(p_se) <- p_tbl[[1]]
+                p_est <- suppressWarnings(as.numeric(p_tbl[["estimate"]]))
+                p_se <- suppressWarnings(as.numeric(p_tbl[["stderr"]]))
+                if (any(is.na(p_est))) {
+                    pz.error(
+                        "Provided phenotype table contains nonnumeric estimates",
+                        .opts=opts)
+                }
+                if (any(is.na(p_se))) {
+                    pz.error(
+                        "Provided phenotype table contains nonnumeric standard errors",
+                        .opts=opts)
+                }
+                if (any(!is.finite(p_est))) {
+                    pz.error(
+                        "Provided phenotype table contains non-finite estimates",
+                        .opts=opts)
+                }
+                if (any(!is.finite(p_se)) || any(p_se <= 0)) {
+                    pz.error(paste0(
+                        "Provided phenotype table standard errors must be ",
+                        "finite and greater than zero"
+                    ), .opts=opts)
+                }
+                names(p_est) <- phenotype_ids
+                names(p_se) <- phenotype_ids
                 ashr_res <- ash_wrapper(p_est, p_se)
                 phenotype <- ashr_res$result %>%
                     tibble::as_tibble(rownames="species") %>%
@@ -195,6 +260,9 @@ calculate_phenotypes <- function(abd.meta, pz.db, ..., .opts=NULL) {
     }
     pz.message("  .....cleaning phenotype")
     phenotype <- clean.pheno(phenotype, pz.db)
+    if (length(phenotype) == 0) {
+        pz.error("No phenotype values matched database taxa", .opts=opts)
+    }
     pz.message(paste0(
         "  ..........Cleaned phenotype retains ",
         length(phenotype),

--- a/package/phylogenize/R/dummy.R
+++ b/package/phylogenize/R/dummy.R
@@ -452,10 +452,9 @@ prep.mtx.for.write <- function(mtx, initial.octo=FALSE) {
 #'
 #' Some options that may be helpful include:
 #' \describe{
-#'   \item{biom_file}{String. Name of BIOM abundance-and-metadata file (in this
-#'   case, to write to disk).}
-#'   \item{biom_dir}{String. Path to BIOM command-line executables. These are
-#'   necessary to write the BIOM file and add the metadata.}
+#'   \item{biom_file}{String. Name of BIOM abundance file to write to disk.}
+#'   \item{metadata_file}{String. Name of separate metadata file to write when
+#'   \code{separate_metadata=TRUE}.}
 #' }
 #'
 #' @param abd.meta List containing a matrix of abundance values, \code{mtx}, and
@@ -468,38 +467,38 @@ write.test.biom <- function(abd.meta,
                             ...,
                             .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
-    cn <- colnames(abd.meta$metadata)
-    colnames(abd.meta$metadata)[which(cn==opts('sample_column'))] <- "#SampleID"
-    abd.meta$mtx <- prep.mtx.for.write(abd.meta$mtx, initial.octo=TRUE)
-    td <- tempdir()
-    af <- file.path(td, "tests/data/test-abundance.tab")
-    mf <- file.path(td, "tests/data/test-metadata.tab")
-    tmp.bf <- tempfile("test-", fileext=".biom")
     bf <- opts('biom_file')
-    if (overwrite) file.remove(tmp.bf)
-    if (overwrite) file.remove(bf)
-    write.test.tabular(abd.meta,
-                       in_dir=tempdir(),
-                       abdfile="tests/data/test-abundance.tab",
-                       metafile="tests/data/test-metadata.tab",
-                       prep=FALSE,
-                       .opts=opts)
-    system2(file.path(opts('biom_dir'), "biom"),
-            args = c("convert",
-                     "-i",
-                     af,
-                     "-o",
-                     tmp.bf,
-                     "--table-type=\"OTU table\"",
-                     "--to-hdf5"))
-    system2(file.path(opts('biom_dir'), "biom"),
-            args = c("add-metadata",
-                     "-i",
-                     tmp.bf,
-                     "-o",
-                     bf,
-                     "--sample-metadata-fp",
-                     mf))
+    if (is.null(bf) || is.na(bf) || bf == "") {
+        pz.error("biom_file must be provided to write a BIOM test fixture")
+    }
+    if (file.exists(bf) && !overwrite) {
+        pz.error(paste0("BIOM file already exists: ", bf))
+    }
+    out_dir <- dirname(bf)
+    if (!dir.exists(out_dir)) {
+        dir.create(out_dir, recursive=TRUE)
+    }
+
+    biom <- biomformat::make_biom(
+        as.matrix(abd.meta$mtx),
+        matrix_element_type="float"
+    )
+    biomformat::write_biom(biom, bf)
+
+    if (opts('separate_metadata')) {
+        mf <- opts('metadata_file')
+        if (is.null(mf) || is.na(mf) || mf == "") {
+            pz.error(
+                "metadata_file must be provided when separate_metadata=TRUE"
+            )
+        }
+        write.table(abd.meta$metadata,
+                    mf,
+                    sep='\t',
+                    row.names=FALSE,
+                    quote=FALSE)
+    }
+    invisible(bf)
 }
 
 

--- a/package/phylogenize/R/fisher-enrich.R
+++ b/package/phylogenize/R/fisher-enrich.R
@@ -79,7 +79,7 @@ multi.enrich <- function(sigs, signs, mappings, dirxn=1) {
       map.bg <- Reduce(union, purrr::map(tbl.mappings$terms,
           ~Reduce(union, .$data)))
       full.table <- tidyr::crossing(taxon, cutoff, tbl.mappings) %>%
-          tidyr::unnest()
+          tidyr::unnest(cols=c(terms))
       full.table <- dplyr::mutate(full.table,
         enr=purrr::pmap(full.table, function(taxon,
             cutoff,
@@ -117,7 +117,7 @@ tbl.result.qvs <- function(results, method=qvals, ...) {
         dplyr::mutate(q.value=purrr::map(data, ~ {
             method(.x$p.value)
         })) %>%
-        tidyr::unnest()
+        tidyr::unnest(cols=c(data, q.value))
     results
 }
 
@@ -151,7 +151,7 @@ alt.multi.enrich <- function(results, mappings, dirxn=1,
                                        ~Reduce(union, .$data)))
     full.table <- tidyr::crossing(
         taxon=taxa, cutoff, tbl.mappings) %>%
-        tidyr::unnest()
+        tidyr::unnest(cols=c(terms))
     map_fxn <- purrr::pmap
     full.table <- dplyr::mutate(full.table,
                          enr=map_fxn(full.table,
@@ -205,4 +205,3 @@ indiv.enr <- function(taxon, cutoff, termset, term, data, results,
 #' @return The same vector with all p-values above 1 changed to exactly 1.
 #' @export
 pv1 <- function(x) { x[which(x > 1)] <- 1; return(x) }
-

--- a/package/phylogenize/R/invoke.R
+++ b/package/phylogenize/R/invoke.R
@@ -212,11 +212,21 @@ render_core_report <- function(core,
             message(paste0(n, ": ", p[[n]]))
         }
     }
-    file.copy(system.file("rmd",
-                          report_input,
-                          package="phylogenize"),
-              opts("out_dir"),
-              overwrite=TRUE)
+    report_template <- system.file("rmd",
+                                   report_input,
+                                   package="phylogenize")
+    if (report_template == "" || !(file.exists(report_template))) {
+        pz.error(paste0("Report template not found: ", report_input),
+                 .opts=opts)
+    }
+    copied_template <- file.copy(report_template,
+                                 opts("out_dir"),
+                                 overwrite=TRUE)
+    if (!isTRUE(copied_template)) {
+        pz.error(paste0("Could not copy report template to output directory: ",
+                        opts("out_dir")),
+                 .opts=opts)
+    }
     pz.message(paste0("Rendering report from ", report_input),
                level=1,
                .opts=opts)

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -975,6 +975,28 @@ sanity.check.abundance <- function(abd.mtx, ...) {
     if (is.null(colnames(abd.mtx))) {
         pz.error("Abundance matrix is lacking column (sample) names")
     }
+    taxon_ids <- trimws(rownames(abd.mtx))
+    sample_ids <- trimws(colnames(abd.mtx))
+    if (any(is.na(taxon_ids)) || any(taxon_ids == "")) {
+        pz.error("Abundance matrix contains blank or missing taxon names")
+    }
+    if (any(is.na(sample_ids)) || any(sample_ids == "")) {
+        pz.error("Abundance matrix contains blank or missing sample names")
+    }
+    if (any(duplicated(taxon_ids))) {
+        duplicate_taxa <- unique(taxon_ids[duplicated(taxon_ids)])
+        pz.error(paste0(
+            "Abundance matrix contains duplicate taxon names: ",
+            paste(duplicate_taxa, collapse=", ")
+        ))
+    }
+    if (any(duplicated(sample_ids))) {
+        duplicate_samples <- unique(sample_ids[duplicated(sample_ids)])
+        pz.error(paste0(
+            "Abundance matrix contains duplicate sample names: ",
+            paste(duplicate_samples, collapse=", ")
+        ))
+    }
     return(TRUE)
 }
 
@@ -1019,6 +1041,17 @@ sanity.check.metadata <- function(metadata, ..., .opts=NULL) {
     }
     if (nrow(metadata) < 2) {
         pz.error("Fewer than two rows found in metadata")
+    }
+    sample_ids <- trimws(as.character(metadata[[opts('sample_column')]]))
+    if (any(is.na(sample_ids)) || any(sample_ids == "")) {
+        pz.error("Metadata contains blank or missing sample IDs")
+    }
+    if (any(duplicated(sample_ids))) {
+        duplicate_samples <- unique(sample_ids[duplicated(sample_ids)])
+        pz.error(paste0(
+            "Metadata contains duplicate sample IDs: ",
+            paste(duplicate_samples, collapse=", ")
+        ))
     }
     return(TRUE)
 }

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -355,34 +355,72 @@ import.pz.db <- function(..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
     db_csv <- file.path(opts('data_dir'), "databases.csv")
     pz.message(paste0("  .....Reading database index: ", db_csv), level=2)
+    if (!(file.exists(db_csv))) {
+        pz.error(paste0("Database index not found: ", db_csv), .opts=opts)
+    }
     installed_dbs <- readr::read_delim(db_csv, show_col_types = FALSE)
+    required_db_columns <- c("database", "genes", "trees", "taxonomy",
+                             "functions")
+    missing_db_columns <- setdiff(required_db_columns, names(installed_dbs))
+    if (length(missing_db_columns) > 0) {
+        pz.error(paste0(
+            "Database index is missing required column(s): ",
+            paste(missing_db_columns, collapse=", ")
+        ), .opts=opts)
+    }
     requested_db <- tolower(opts('db'))
     pz.message(paste0("  .....Requested database: ", requested_db))
     if (!(requested_db %in% installed_dbs[["database"]])) {
         pz.error(paste0("Database not installed in ", opts('data_dir'), ": ",
-                        opts('db')))
+                        opts('db')),
+                 .opts=opts)
     }
     found_db <- dplyr::filter(installed_dbs, database==requested_db)
     if (nrow(found_db) > 1) {
-        pz.error(paste0("Duplicate data entries in db file: ", db_csv))
+        pz.error(paste0("Duplicate data entries in db file: ", db_csv),
+                 .opts=opts)
+    }
+    db_paths <- vapply(required_db_columns[-1], function(col) {
+        file.path(opts('data_dir'), found_db[[col]])
+    }, character(1))
+    missing_db_files <- db_paths[!(file.exists(db_paths))]
+    if (length(missing_db_files) > 0) {
+        pz.error(paste0(
+            "Database file(s) not found: ",
+            paste(unname(missing_db_files), collapse=", ")
+        ), .opts=opts)
     }
 
     pz.message("  .....Read in phylogenize2 gene presence file")
-    gene.presence <- readRDS(file.path(opts('data_dir'),
-                                       found_db[["genes"]]))
+    gene.presence <- readRDS(db_paths[["genes"]])
     gene.presence <- gene.presence[names(gene.presence) != ""]
+    if (!(is.list(gene.presence)) || length(gene.presence) == 0) {
+        pz.error("Gene presence database must be a non-empty named list",
+                 .opts=opts)
+    }
     pz.message(paste0(
         "  ..........Loaded ",
         length(gene.presence),
         " gene presence matrix/matrices"
     ))
     pz.message("  .....Read in phylogenize2 tree file")
-    trees <- readRDS(file.path(opts('data_dir'),
-                               found_db[["trees"]]))
+    trees <- readRDS(db_paths[["trees"]])
+    if (!(is.list(trees)) || length(trees) == 0) {
+        pz.error("Tree database must be a non-empty named list", .opts=opts)
+    }
     pz.message(paste0("  ..........Loaded ", length(trees), " tree(s)"))
     pz.message("  .....Read in phylogenize2 taxonomy file")
-    taxonomy <- readr::read_csv(file.path(opts('data_dir'),
-                                          found_db[["taxonomy"]]), show_col_types=FALSE)
+    taxonomy <- readr::read_csv(db_paths[["taxonomy"]], show_col_types=FALSE)
+    required_taxonomy_columns <- c("cluster", "species", "genus", "family",
+                                   "order", "class", "phylum", "domain")
+    missing_taxonomy_columns <- setdiff(required_taxonomy_columns,
+                                        names(taxonomy))
+    if (length(missing_taxonomy_columns) > 0) {
+        pz.error(paste0(
+            "Taxonomy file is missing required column(s): ",
+            paste(missing_taxonomy_columns, collapse=", ")
+        ), .opts=opts)
+    }
     pz.message(paste0(
         "  ..........Loaded taxonomy with ",
         nrow(taxonomy),
@@ -406,9 +444,18 @@ import.pz.db <- function(..., .opts=NULL) {
 
     pz.message("  .....Read in phylogenize2 gene functions file")
     gene.to.fxn <- readr::read_csv(
-        file.path(opts('data_dir'), found_db[["functions"]]),
+        db_paths[["functions"]],
         show_col_types = FALSE
     )
+    required_function_columns <- c("node_head", "accession", "function")
+    missing_function_columns <- setdiff(required_function_columns,
+                                        names(gene.to.fxn))
+    if (length(missing_function_columns) > 0) {
+        pz.error(paste0(
+            "Gene function file is missing required column(s): ",
+            paste(missing_function_columns, collapse=", ")
+        ), .opts=opts)
+    }
     pz.message(paste0(
         "  ..........Loaded ",
         nrow(gene.to.fxn),

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -131,6 +131,10 @@ check.process.metadata <- function(metadata, ..., .opts=NULL) {
     if (opts('categorical')) {   # i.e., env not continuous
         env_factor <- factor(metadata[[E]])
         env_levels <- levels(env_factor)
+        if (any(is.na(env_factor))) {
+            pz.error(paste0("environment column contains missing values: ", E),
+                     .opts=opts)
+        }
         
         if (!(envir %in% env_levels)) {
             pz.error(paste0("environment ", envir, " not found in metadata"))
@@ -138,21 +142,37 @@ check.process.metadata <- function(metadata, ..., .opts=NULL) {
         env_factor <- forcats::fct_relevel(env_factor, envir, after=Inf)
         metadata[[E]] <- env_factor
     } else {
-        metadata[[E]] <- as.numeric(metadata[[E]])
-        if (all(is.na(metadata[[E]]))) {
+        env_original <- metadata[[E]]
+        env_numeric <- suppressWarnings(as.numeric(env_original))
+        converted_to_na <- is.na(env_numeric) & !is.na(env_original)
+        if (any(converted_to_na)) {
+            pz.error(paste0(
+                "Environment column contains nonnumeric value(s): ",
+                paste(unique(env_original[converted_to_na]), collapse=", ")
+            ), .opts=opts)
+        }
+        if (any(is.na(env_numeric))) {
+            pz.error(paste0("environment column contains missing values: ", E),
+                     .opts=opts)
+        }
+        if (length(env_numeric) == 0) {
             pz.error(
                 paste0("Environment failed conversion to numeric; is this ",
-                       "supposed to be a categorical variable?"))
+                       "supposed to be a categorical variable?"),
+                .opts=opts)
         }
+        metadata[[E]] <- env_numeric
     }
     metadata[[opts('dset_column')]] <- as.factor(metadata[[opts('dset_column')]])
     
     # One more sanity check before we return
     if (converted_rownames) orig_md <- tibble::as_tibble(orig_md, rownames=S)
     compare_md <- dplyr::full_join(orig_md[c(S, E)], metadata[c(S, E)], by=S)
-    wrong_rows <- compare_md[
-        compare_md[[paste0(E, ".x")]] != compare_md[[paste0(E, ".y")]],
-    ]
+    env_before <- compare_md[[paste0(E, ".x")]]
+    env_after <- compare_md[[paste0(E, ".y")]]
+    wrong_env <- (is.na(env_before) != is.na(env_after)) |
+        (!is.na(env_before) & !is.na(env_after) & env_before != env_after)
+    wrong_rows <- compare_md[wrong_env, ]
     if (nrow(wrong_rows) > 0) {
         print(wrong_rows)
         pz.error(

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -1124,24 +1124,71 @@ remove.allzero.abundances <- function(abd.mtx, ..., .opts=NULL) {
 #'   be unzipped) or a .csv file (which will be copied).
 #' @param force Boolean; overwrite existing files? (Default: FALSE)
 #' @export
-install_data <- function(path, force=FALSE) {
+install_data <- function(path, force=FALSE,
+                         .extd_path=system.file("extdata/",
+                                                package="phylogenize")) {
+    if (!is.character(path) || length(path) != 1 ||
+        is.na(path) || trimws(path) == "") {
+        pz.error("path must be a single non-empty file path")
+    }
+    if (!file.exists(path)) {
+        pz.error(paste0("Data archive not found: ", path))
+    }
+    if (!dir.exists(.extd_path)) {
+        pz.error(paste0(
+            "phylogenize extdata directory not found: ",
+            .extd_path
+        ))
+    }
+    if (file.access(.extd_path, mode=2) != 0) {
+        pz.error(paste0(
+            "phylogenize extdata directory is not writable: ",
+            .extd_path
+        ))
+    }
     fn <- basename(path)
-    extd_path <- system.file("extdata/", package="phylogenize")
-    if (stringr::str_ends(basename(path), "\\.csv")) {
-        if (!file.exists(file.path(extd_path, fn)) || force) {
-            print(paste0(
-                "Copying ",
-                path,
-                " to ",
-                system.file("", package="phylogenize")))
-            file.copy(path, extd_path, overwrite = force)
+    ext <- tolower(tools::file_ext(path))
+    if (ext == "csv") {
+        dest <- file.path(.extd_path, fn)
+        if (file.exists(dest) && !force) {
+            pz.error(paste0(
+                "Destination file already exists; use force=TRUE to overwrite: ",
+                dest
+            ))
         }
-    } else {
-        print(paste0(
+        pz.message(paste0(
+            "Copying ",
+            path,
+            " to ",
+            .extd_path
+        ))
+        ok <- file.copy(path, .extd_path, overwrite=force)
+        if (!isTRUE(ok)) {
+            pz.error(paste0("Could not copy data file to: ", dest))
+        }
+        return(invisible(dest))
+    }
+    if (ext == "zip") {
+        pz.message(paste0(
             "Unzipping ",
             path,
             " to ",
-            system.file("", package="phylogenize")))
-        unzip(path, overwrite = force, exdir = extd_path)
+            .extd_path
+        ))
+        out <- tryCatch(
+            unzip(path, overwrite=force, exdir=.extd_path),
+            error=function(e) {
+                pz.error(paste0("Could not unzip data archive: ", e$message))
+            }
+        )
+        if (length(out) == 0) {
+            pz.error("Zip archive did not install any files")
+        }
+        return(invisible(out))
     }
+    pz.error(paste0(
+        "Unsupported data file extension: .",
+        ext,
+        ". Expected .csv or .zip"
+    ))
 }

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -306,11 +306,18 @@ read.abd.metadata.tabular <- function(..., .opts=NULL) {
             list(.default=readr::col_double())
         )
     )
-    abd.df <- readr::read_tsv(
-        af,
-        col_select=tidyselect::all_of(abundance_keep_cols),
-        col_types=abundance_col_types,
-        show_col_types=FALSE
+    abd.df <- withCallingHandlers(
+        readr::read_tsv(
+            af,
+            col_select=tidyselect::all_of(abundance_keep_cols),
+            col_types=abundance_col_types,
+            show_col_types=FALSE
+        ),
+        warning=function(w) {
+            if (inherits(w, "vroom_parse_issue")) {
+                invokeRestart("muffleWarning")
+            }
+        }
     )
     abd.values <- abd.df[, -1, drop=FALSE]
     bad.cols <- names(abd.values)[

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -203,7 +203,10 @@ check.process.metadata <- function(metadata, ..., .opts=NULL) {
 read.abd.metadata.biom <- function(..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
     bf <- opts('biom_file')
-    pz.message(paste0("looking for file: ", normalizePath(bf)), level=2)
+    pz.message(paste0(
+        "looking for file: ",
+        normalizePath(bf, mustWork=FALSE)
+    ), level=2)
     if (!(file.exists(bf))) {
         pz.error(paste0("file not found: ", bf))
     } else { pz.message(paste0("located biom file: ", bf), level=2) }

--- a/package/phylogenize/R/options.R
+++ b/package/phylogenize/R/options.R
@@ -177,6 +177,27 @@ pz.resolve.options <- function(..., .opts=NULL) {
     do.call(settings::clone_and_merge, c(list(.opts), dots))
 }
 
+read.internal.database.index <- function(db_csv) {
+    db <- utils::read.csv(
+        db_csv,
+        check.names=FALSE,
+        stringsAsFactors=FALSE,
+        na.strings=c("", "NA"),
+        fill=TRUE
+    )
+    required <- "database"
+    if (!(required %in% colnames(db))) {
+        pz.error(sprintf(
+            "databases.csv is missing required column: %s",
+            required
+        ))
+    }
+    if (any(is.na(db$database) | trimws(db$database) == "")) {
+        pz.error("databases.csv contains blank database names")
+    }
+    db
+}
+
 #' Set data directory to internal
 #'
 #' @param fail Boolean. If TRUE, set_data_internal will not attempt to download
@@ -200,7 +221,7 @@ set_data_internal <- function(fail=FALSE, startup=FALSE) {
             M(sprintf("Note: databases.csv was not found under directory '%s'. You will need to manually set the directory later with the option 'data_dir=<PATH>'.", phd))
         } else {
             success <- TRUE
-            db <- readr::read_delim(dd)
+            db <- read.internal.database.index(dd)
             M(sprintf("Databases listed:\n\t - %s", paste0(db[["database"]], collapse="\n\t - ")))
         }
     #}
@@ -233,7 +254,7 @@ check_data_found <- function(fail=FALSE, startup=FALSE) {
             ))
         } else {
             success <- TRUE
-            db <- readr::read_delim(dd)
+            db <- read.internal.database.index(dd)
             M(sprintf(
                 "Databases listed:\n\t - %s",
                 paste0(db[["database"]], collapse = "\n\t - ")

--- a/package/phylogenize/R/plm-functions.R
+++ b/package/phylogenize/R/plm-functions.R
@@ -1619,7 +1619,7 @@ above_minimum_genes <- function(gene.presence, trees, ..., .opts=NULL) {
 #' @export
 add.sig.descs <- function(phy.with.sigs, pos.sig, gene.to.fxn) {
     pos.sig.tbl <- tibble::enframe(pos.sig, name="taxon", value="gene") %>%
-        tidyr::unnest()
+        tidyr::unnest(cols=c(gene))
     
     column_names <- colnames(gene.to.fxn)
     na_columns <- which(is.na(column_names))

--- a/package/phylogenize/R/plm-functions.R
+++ b/package/phylogenize/R/plm-functions.R
@@ -213,6 +213,24 @@ result.wrapper.plm <- function(
     })
 }
 
+filter.incomplete.metadata.samples <- function(metadata, mtx, required_cols) {
+    missing_cols <- setdiff(required_cols, colnames(metadata))
+    if (length(missing_cols) > 0) {
+        pz.error(paste0(
+            "metadata is missing required column(s): ",
+            paste(missing_cols, collapse=", ")
+        ))
+    }
+    complete_rows <- stats::complete.cases(metadata[, required_cols, drop=FALSE])
+    metadata <- metadata[complete_rows, , drop=FALSE]
+    metadata <- droplevels(metadata)
+    shared_samples <- intersect(rownames(metadata), colnames(mtx))
+    list(
+        metadata=metadata[shared_samples, , drop=FALSE],
+        mtx=mtx[, shared_samples, drop=FALSE]
+    )
+}
+
 #' Perform POMS modeling for a single clade.
 #'
 #' Some particularly relevant options are:

--- a/package/phylogenize/R/plm-functions.R
+++ b/package/phylogenize/R/plm-functions.R
@@ -1113,6 +1113,27 @@ calc.ess <- function(abd.meta,
         stop("not implemented yet, sorry")
     } else if (ptype == "file") {
         priors <- pdata[pdata$env %in% envirs, , drop=FALSE]
+        missing_prior_envs <- setdiff(as.character(envirs),
+                                      as.character(priors$env))
+        if (length(missing_prior_envs) > 0) {
+            pz.error(paste0(
+                "Prior file does not include retained environment(s): ",
+                paste(missing_prior_envs, collapse=", ")
+            ), .opts=opts)
+        }
+        prior_sum <- sum(priors$prior)
+        if (!is.finite(prior_sum) || prior_sum <= 0) {
+            pz.error("Prior file priors must sum to a positive finite value",
+                     .opts=opts)
+        }
+        if (!isTRUE(all.equal(prior_sum, 1, tolerance=1e-6))) {
+            pz.warning(paste0(
+                "Prior values for retained environments sum to ",
+                signif(prior_sum, 4),
+                "; normalizing to sum to 1"
+            ), .opts=opts)
+            priors$prior <- priors$prior / prior_sum
+        }
     } else {
         stop(paste0("don't know how to compute priors of type ", ptype))
     }

--- a/package/phylogenize/R/process-16S.R
+++ b/package/phylogenize/R/process-16S.R
@@ -64,13 +64,38 @@ prepare.vsearch.input <- function(mtx, ..., .opts=NULL) {
 #' @export run.vsearch
 run.vsearch <- function(..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
-    binary = basename(opts('vsearch_dir'))
-    pid = opts('vsearch_cutoff')
+    vsearch_path <- opts('vsearch_dir')
+    if (dir.exists(vsearch_path)) {
+        vsearch_path <- file.path(vsearch_path, "vsearch")
+    }
+    if (vsearch_path == "" || !(file.exists(vsearch_path))) {
+        pz.error(paste0("vsearch executable not found: ", opts('vsearch_dir')),
+                 .opts=opts)
+    }
+    if (file.access(vsearch_path, mode=1) != 0) {
+        pz.error(paste0("vsearch executable is not runnable: ", vsearch_path),
+                 .opts=opts)
+    }
+    query_file <- opts('named_asv_file')
+    if (!(file.exists(query_file))) {
+        pz.error(paste0("16S query FASTA not found: ", query_file),
+                 .opts=opts)
+    }
+    db_file <- file.path(opts('data_dir'), opts('vsearch_16sfile'))
+    if (!(file.exists(db_file))) {
+        pz.error(paste0("16S reference FASTA not found: ", db_file),
+                 .opts=opts)
+    }
+    pid <- suppressWarnings(as.numeric(opts('vsearch_cutoff')))
+    if (is.na(pid) || pid <= 0 || pid > 1) {
+        pz.error("vsearch_cutoff must be a number greater than 0 and at most 1",
+                 .opts=opts)
+    }
+    binary = basename(vsearch_path)
     vsearch_args = c("--db",
-			     file.path(opts('data_dir'),
-				       opts('vsearch_16sfile')),
+			     db_file,
 			     "--usearch_global",
-			     opts('named_asv_file'),
+			     query_file,
 			     "--strand",
 			     "both",
 			     "--id",
@@ -82,7 +107,7 @@ run.vsearch <- function(..., .opts=NULL) {
     pz.message(paste0("Calling aligner ", binary, " with arguments: ",
                       paste(vsearch_args, sep=" ", collapse=" ")),
                .opts=opts)
-    r <- system2(opts('vsearch_dir'),
+    r <- system2(vsearch_path,
                  args = vsearch_args)
     if (r != 0) {
         pz.error(paste0("Aligner failed with error code ", r), .opts=opts)
@@ -109,15 +134,53 @@ run.vsearch <- function(..., .opts=NULL) {
 #' @export
 get.vsearch.results <- function(..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
+    vf <- opts('vsearch_outfile')
+    if (!(file.exists(vf))) {
+        pz.error(paste0("vsearch output file not found: ", vf), .opts=opts)
+    }
+    if (file.info(vf)$size == 0) {
+        pz.error(paste0("vsearch output file was empty: ", vf), .opts=opts)
+    }
     # map to MIDAS IDs using vsearch (note X1 is query name, X3 is pctid)
     assignments <- 
-        readr::read_tsv(opts('vsearch_outfile'), col_names=FALSE) %>%
-	dplyr::group_by(X1) %>%
+        readr::read_tsv(vf, col_names=FALSE, show_col_types=FALSE)
+    if (ncol(assignments) < 3) {
+        pz.error("vsearch output must contain at least 3 tab-delimited columns",
+                 .opts=opts)
+    }
+    if (nrow(assignments) == 0) {
+        pz.error(paste0("vsearch output file had no assignments: ", vf),
+                 .opts=opts)
+    }
+    pct_id <- suppressWarnings(as.numeric(assignments[[3]]))
+    if (any(is.na(pct_id))) {
+        pz.error("vsearch output contains nonnumeric percent identity values",
+                 .opts=opts)
+    }
+    assignments[[3]] <- pct_id
+    query_ok <- grepl("^Row[0-9]+$", assignments[[1]])
+    if (any(!query_ok)) {
+        pz.error(paste0(
+            "vsearch output contains invalid query ID(s): ",
+            paste(unique(assignments[[1]][!query_ok]), collapse=", ")
+        ), .opts=opts)
+    }
+    target_parts <- strsplit(assignments[[2]], ";;", fixed=TRUE)
+    target_ok <- vapply(target_parts, length, integer(1)) >= 3
+    if (any(!target_ok)) {
+        pz.error(paste0(
+            "vsearch output contains malformed target ID(s): ",
+            paste(unique(assignments[[2]][!target_ok]), collapse=", ")
+        ), .opts=opts)
+    }
+    assignments <- assignments %>%
+        dplyr::group_by(X1) %>%
         dplyr::slice_max(X3) %>%
 	dplyr::ungroup()
     row.hits <- as.numeric(gsub("Row", "", assignments[[1]]))
-    row.targets <- sapply(assignments[[2]],
-                          function(x) strsplit(x, ";;")[[1]][3])
+    row.targets <- vapply(strsplit(assignments[[2]], ";;", fixed=TRUE),
+                          function(x) x[[3]],
+                          character(1))
     return(list(hits=row.hits, targets=row.targets, assn=assignments))
 }
 

--- a/package/phylogenize/R/significance.R
+++ b/package/phylogenize/R/significance.R
@@ -56,10 +56,12 @@ nonequiv.pos.sig <- function(results,
         }
         #tryCatch(
         #    {
-                tested <- na.omit(unlist(r[2, valid, drop = FALSE]))
-                if ("matrix" %in% class(tested)) {
-                    tested <- tested[1, ]
-                }
+                tested <- unlist(r[2, valid, drop = FALSE])
+                if (is.null(names(tested))) names(tested) <- valid
+                tested_names <- names(tested)
+                tested <- as.numeric(tested)
+                names(tested) <- tested_names
+                tested <- stats::na.omit(tested)
                 qv <- call_method(tested)
                 fx_sig <- nw(qv <= qcut_sig)
                 neq_sig <- valid
@@ -79,9 +81,10 @@ nonequiv.pos.sig <- function(results,
                     }
                 }
                 fx_sizes <- unlist(r[1, valid, drop=FALSE])
-                if ("matrix" %in% class(fx_sizes)) {
-                    fx_sizes <- fx_sizes[1, ]
-                }
+                if (is.null(names(fx_sizes))) names(fx_sizes) <- valid
+                fx_names <- names(fx_sizes)
+                fx_sizes <- as.numeric(fx_sizes)
+                names(fx_sizes) <- fx_names
                 which_pos <- nw((dir * fx_sizes) > 0)
                 Reduce(intersect, list(fx_sig, neq_sig, which_pos))
           #  },
@@ -289,8 +292,13 @@ qvals <- function(x, ..., .opts=NULL) {
     if (length(x) == 0) {
         return(x)
     }
-    x_numeric <- suppressWarnings(as.numeric(x))
-    names(x_numeric) <- names(x)
+    x_unlisted <- unlist(x)
+    x_numeric <- suppressWarnings(as.numeric(x_unlisted))
+    x_names <- names(x_unlisted)
+    if (is.null(x_names) && !is.null(dim(x)) && ncol(x) == length(x_numeric)) {
+        x_names <- colnames(x)
+    }
+    names(x_numeric) <- x_names
     nonmissing <- !is.na(x_numeric)
     if (any(!is.finite(x_numeric[nonmissing])) ||
         any(x_numeric[nonmissing] < 0 | x_numeric[nonmissing] > 1)) {

--- a/package/phylogenize/R/significance.R
+++ b/package/phylogenize/R/significance.R
@@ -277,23 +277,51 @@ get.top.N <- function(p,
 #' @keywords internal
 qvals <- function(x, ..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
-    if (toupper(opts("fdr_method"))=="BH") {
-        return(p.adjust(x, 'BH'))
+    method <- tolower(opts("fdr_method"))
+    valid_methods <- c("bh", "by", "qvalue")
+    if (!(method %in% valid_methods)) {
+        pz.error(paste0(
+            "Invalid fdr_method: ",
+            opts("fdr_method"),
+            ". Expected one of: BH, BY, qvalue"
+        ), .opts=opts)
     }
-    if (toupper(opts("fdr_method"))=="BY") {
-        return(p.adjust(x, 'BY'))
+    if (length(x) == 0) {
+        return(x)
     }
-    if (tolower(opts("fdr_method"))=="qvalue") {
-        q <- tryCatch(qvalue::qvalue(x,
+    x_numeric <- suppressWarnings(as.numeric(x))
+    names(x_numeric) <- names(x)
+    nonmissing <- !is.na(x_numeric)
+    if (any(!is.finite(x_numeric[nonmissing])) ||
+        any(x_numeric[nonmissing] < 0 | x_numeric[nonmissing] > 1)) {
+        pz.error("p-values must be finite values between 0 and 1",
+                 .opts=opts)
+    }
+    q <- rep(NA_real_, length(x_numeric))
+    names(q) <- names(x_numeric)
+    if (!any(nonmissing)) {
+        return(q)
+    }
+    x_valid <- x_numeric[nonmissing]
+    if (method=="bh") {
+        q[nonmissing] <- p.adjust(x_valid, 'BH')
+        return(q)
+    }
+    if (method=="by") {
+        q[nonmissing] <- p.adjust(x_valid, 'BY')
+        return(q)
+    }
+    if (method=="qvalue") {
+        q[nonmissing] <- tryCatch(qvalue::qvalue(x_valid,
                                      fdr=T,
                                      lambda=seq(0.001, 0.95, 0.005))$qvalues,
                       error=function(e) {
                           pz.warning("Trying lambda=0...", ...)
-                          tryCatch(qvalue::qvalue(x, fdr=T, lambda=0)$qvalues,
+                          tryCatch(qvalue::qvalue(x_valid, fdr=T, lambda=0)$qvalues,
                                    error=function(e) {
                                        pz.warning(e, ...)
                                        pz.warning("Falling back to BH", ...)
-                                       p.adjust(x, 'BH')
+                                       p.adjust(x_valid, 'BH')
                                    })
                       })
         return(q)

--- a/package/phylogenize/R/significance.R
+++ b/package/phylogenize/R/significance.R
@@ -180,9 +180,11 @@ make.sigs <- function(
 #' @return List (per taxon) of numeric vectors of signs of hits.
 #' @export
 make.signs <- function(results) {
-  lapply(results, function(r) {
-    sign(unlist(r[1, , drop=FALSE])) %>% na.omit
-  })
+    lapply(results, function(r) {
+        fx <- as.numeric(r[1, , drop=FALSE])
+        names(fx) <- colnames(r)
+        stats::na.omit(sign(fx))
+    })
 }
 
 #' Calculate the FPR and (1 - FNR) for results of a set of tests.

--- a/package/phylogenize/R/trees.R
+++ b/package/phylogenize/R/trees.R
@@ -9,14 +9,26 @@
 #'     maximum node height.
 #' @keywords internal
 fix.tree <- function(phy, len=1e-6) {
-  if (!is.null(phy) && inherits(phy, "phylo")) {
-      phy <- ape::multi2di(phy)
-      if (any(phy$edge.length == 0)) {
-          max_height <- max(castor::get_all_distances_to_root(phy))
-          phy$edge.length[phy$edge.length == 0] <- max_height * len
-      }
-  }
-  phy
+    if (!is.null(phy) && inherits(phy, "phylo")) {
+        phy <- ape::multi2di(phy)
+        if (is.null(phy$edge.length)) {
+            phy$edge.length <- rep(1, nrow(phy$edge))
+        }
+        valid_lengths <- phy$edge.length[
+            is.finite(phy$edge.length) & phy$edge.length > 0
+        ]
+        if (length(valid_lengths) > 0) {
+            replacement_length <- min(valid_lengths) * len
+        } else {
+            replacement_length <- len
+        }
+        if (!is.finite(replacement_length) || replacement_length <= 0) {
+            replacement_length <- len
+        }
+        bad_lengths <- !is.finite(phy$edge.length) | phy$edge.length <= 0
+        phy$edge.length[bad_lengths] <- replacement_length
+    }
+    phy
 }
 
 #' Keep some tips on a tree.

--- a/package/phylogenize/tests/testthat/test-calc-phenotypes.R
+++ b/package/phylogenize/tests/testthat/test-calc-phenotypes.R
@@ -282,6 +282,129 @@ test_that("specificity prior files must cover retained environments", {
     )
 })
 
+test_that("prevalence phenotype uses additive smoothing with fixed values", {
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 0, 1,
+              0, 0, 0,
+              1, 1, 1),
+            nrow=3,
+            byrow=TRUE,
+            dimnames=list(
+                c("taxon_present_two", "taxon_absent", "taxon_present_all"),
+                paste0("s", 1:3)
+            )
+        ),
+        metadata=data.frame(
+            sample=paste0("s", 1:3),
+            dataset=rep("d1", 3),
+            env=factor(rep("A", 3))
+        )
+    )
+
+    observed <- prev.addw(
+        abd.meta,
+        sample_column="sample",
+        dset_column="dataset",
+        env_column="env",
+        which_envir="A",
+        error_to_file=FALSE
+    )
+    expected <- c(
+        taxon_present_two=logit(3 / 5),
+        taxon_absent=logit(1 / 5),
+        taxon_present_all=logit(4 / 5)
+    )
+
+    expect_equal(observed, expected, tolerance=1e-12)
+})
+
+test_that("specificity phenotype shrinkage has stable numeric values", {
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 1, 0, 0,
+              0, 0, 1, 1,
+              1, 0, 1, 0),
+            nrow=3,
+            byrow=TRUE,
+            dimnames=list(
+                c("A_specific", "B_specific", "mixed"),
+                paste0("s", 1:4)
+            )
+        ),
+        metadata=data.frame(
+            sample=paste0("s", 1:4),
+            dataset=rep("d1", 4),
+            env=factor(c("A", "A", "B", "B"))
+        )
+    )
+
+    observed <- suppressWarnings(calc.ess(
+        abd.meta,
+        b.optim=1,
+        sample_column="sample",
+        dset_column="dataset",
+        env_column="env",
+        which_envir="A",
+        prior_type="uninformative",
+        error_to_file=FALSE
+    ))
+
+    expect_equal(unname(observed$phenoP), logit(0.5), tolerance=1e-12)
+    expect_equal(
+        observed$ess,
+        c(A_specific=0.6931484, B_specific=0, mixed=0),
+        tolerance=1e-6
+    )
+    expect_equal(
+        observed$regularized["x.init", ],
+        c(A_specific=0.75, B_specific=0.25, mixed=0.5),
+        tolerance=1e-12
+    )
+    expect_equal(
+        observed$regularized["pT", ],
+        c(A_specific=0.5, B_specific=0.5, mixed=0.5),
+        tolerance=1e-12
+    )
+})
+
+test_that("CLR correlation phenotype has stable numeric values", {
+    trait <- c(-1, 0, 1, 2)
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 2, 4, 8,
+              8, 4, 2, 1,
+              3, 3, 3, 3),
+            nrow=3,
+            byrow=TRUE,
+            dimnames=list(
+                c("increasing", "decreasing", "flat"),
+                paste0("s", 1:4)
+            )
+        ),
+        metadata=data.frame(
+            sample=paste0("s", 1:4),
+            dataset=rep("d1", 4),
+            env=trait
+        )
+    )
+
+    observed <- correl.clr(
+        abd.meta,
+        sample_column="sample",
+        dset_column="dataset",
+        env_column="env",
+        error_to_file=FALSE
+    )
+    expected <- c(
+        increasing=4.776264,
+        decreasing=-4.776264,
+        flat=0
+    )
+
+    expect_equal(observed, expected, tolerance=1e-6)
+})
+
 test_that("quantile_normalize preserves prevalence phenotypes with NULL phenoP", {
     phenotype_results <- list(
         phenotype=c(taxon1=2, taxon2=1, taxon3=3),

--- a/package/phylogenize/tests/testthat/test-calc-phenotypes.R
+++ b/package/phylogenize/tests/testthat/test-calc-phenotypes.R
@@ -1,3 +1,34 @@
+calc_phenotype_fixture <- function() {
+    list(
+        abd.meta=list(
+            mtx=Matrix::Matrix(
+                matrix(
+                    c(1, 0, 0,
+                      0, 1, 0,
+                      0, 0, 1),
+                    nrow=3,
+                    byrow=TRUE,
+                    dimnames=list(paste0("s", 1:3), paste0("sample", 1:3))
+                ),
+                sparse=TRUE
+            )
+        ),
+        pz.db=list(
+            trees=list(TaxonA=ape::read.tree(text="(s1:1,s2:1,s3:1);")),
+            gene.presence=list(
+                TaxonA=Matrix::Matrix(
+                    matrix(
+                        c(1, 1, 0),
+                        nrow=1,
+                        dimnames=list("gene1", paste0("s", 1:3))
+                    ),
+                    sparse=TRUE
+                )
+            )
+        )
+    )
+}
+
 test_that("calculate_phenotypes uses direct treemin override", {
     old_opts <- pz.options()
     on.exit(do.call(pz.options, old_opts), add=TRUE)
@@ -50,6 +81,61 @@ test_that("calculate_phenotypes uses direct treemin override", {
     )
 
     expect_equal(phenotype_results$phenotype, c(s1=1, s2=2, s3=3))
+})
+
+test_that("provided phenotype input is validated before use", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    fixture <- calc_phenotype_fixture()
+    calculate_provided <- function(phenotype_file) {
+        calculate_phenotypes(
+            fixture$abd.meta,
+            fixture$pz.db,
+            which_phenotype="provided",
+            phenotype_file=phenotype_file,
+            treemin=2,
+            error_to_file=FALSE
+        )
+    }
+
+    expect_error(
+        calculate_provided(file.path(tempdir(), "missing-phenotype.tsv")),
+        "Phenotype file not found"
+    )
+
+    duplicate_file <- tempfile(fileext=".tsv")
+    writeLines(c(
+        "species\tphenotype",
+        "s1\t1",
+        " s1 \t2"
+    ), duplicate_file)
+    expect_error(
+        calculate_provided(duplicate_file),
+        "duplicate taxon IDs"
+    )
+
+    nonnumeric_file <- tempfile(fileext=".tsv")
+    writeLines(c(
+        "species\tphenotype",
+        "s1\t1",
+        "s2\tbad"
+    ), nonnumeric_file)
+    expect_error(
+        calculate_provided(nonnumeric_file),
+        "nonnumeric phenotype values"
+    )
+
+    no_overlap_file <- tempfile(fileext=".tsv")
+    writeLines(c(
+        "species\tphenotype",
+        "x1\t1",
+        "x2\t2"
+    ), no_overlap_file)
+    expect_error(
+        calculate_provided(no_overlap_file),
+        "No phenotype values matched database taxa"
+    )
 })
 
 test_that("quantile_normalize preserves prevalence phenotypes with NULL phenoP", {

--- a/package/phylogenize/tests/testthat/test-calc-phenotypes.R
+++ b/package/phylogenize/tests/testthat/test-calc-phenotypes.R
@@ -138,6 +138,56 @@ test_that("provided phenotype input is validated before use", {
     )
 })
 
+test_that("provided phenotype shrinkage input is validated before use", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    fixture <- calc_phenotype_fixture()
+    calculate_provided <- function(phenotype_file) {
+        calculate_phenotypes(
+            fixture$abd.meta,
+            fixture$pz.db,
+            which_phenotype="provided",
+            phenotype_file=phenotype_file,
+            treemin=2,
+            error_to_file=FALSE
+        )
+    }
+
+    missing_stderr_file <- tempfile(fileext=".tsv")
+    writeLines(c(
+        "species\testimate\tnote",
+        "s1\t1\tok",
+        "s2\t2\tok"
+    ), missing_stderr_file)
+    expect_error(
+        calculate_provided(missing_stderr_file),
+        "missing required column"
+    )
+
+    bad_estimate_file <- tempfile(fileext=".tsv")
+    writeLines(c(
+        "species\testimate\tstderr",
+        "s1\tbad\t0.2",
+        "s2\t2\t0.3"
+    ), bad_estimate_file)
+    expect_error(
+        calculate_provided(bad_estimate_file),
+        "nonnumeric estimates"
+    )
+
+    bad_stderr_file <- tempfile(fileext=".tsv")
+    writeLines(c(
+        "species\testimate\tstderr",
+        "s1\t1\t0",
+        "s2\t2\t-0.3"
+    ), bad_stderr_file)
+    expect_error(
+        calculate_provided(bad_stderr_file),
+        "standard errors must be"
+    )
+})
+
 test_that("specificity prior files are resolved and validated", {
     old_opts <- pz.options()
     on.exit(do.call(pz.options, old_opts), add=TRUE)

--- a/package/phylogenize/tests/testthat/test-calc-phenotypes.R
+++ b/package/phylogenize/tests/testthat/test-calc-phenotypes.R
@@ -138,6 +138,100 @@ test_that("provided phenotype input is validated before use", {
     )
 })
 
+test_that("specificity prior files are resolved and validated", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    fixture <- calc_phenotype_fixture()
+    calculate_specificity <- function(prior_file, working_dir=tempdir()) {
+        calculate_phenotypes(
+            fixture$abd.meta,
+            fixture$pz.db,
+            which_phenotype="specificity",
+            prior_type="file",
+            prior_file=prior_file,
+            working_dir=working_dir,
+            error_to_file=FALSE
+        )
+    }
+
+    expect_error(
+        calculate_specificity("missing-prior.tsv"),
+        "Prior file not found"
+    )
+
+    tmp <- tempfile("prior-dir-")
+    dir.create(tmp)
+
+    missing_column_file <- file.path(tmp, "missing-column.tsv")
+    writeLines(c(
+        "env\tweight",
+        "A\t0.5",
+        "B\t0.5"
+    ), missing_column_file)
+    expect_error(
+        calculate_specificity("missing-column.tsv", working_dir=tmp),
+        "missing required column"
+    )
+
+    duplicate_env_file <- file.path(tmp, "duplicate-env.tsv")
+    writeLines(c(
+        "env\tprior",
+        "A\t0.5",
+        " A \t0.5"
+    ), duplicate_env_file)
+    expect_error(
+        calculate_specificity("duplicate-env.tsv", working_dir=tmp),
+        "duplicate environments"
+    )
+
+    nonnumeric_prior_file <- file.path(tmp, "nonnumeric-prior.tsv")
+    writeLines(c(
+        "env\tprior",
+        "A\t0.5",
+        "B\tbad"
+    ), nonnumeric_prior_file)
+    expect_error(
+        calculate_specificity("nonnumeric-prior.tsv", working_dir=tmp),
+        "nonnumeric prior values"
+    )
+})
+
+test_that("specificity prior files must cover retained environments", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 0, 1, 0,
+              0, 1, 0, 1),
+            nrow=2,
+            byrow=TRUE,
+            dimnames=list(c("s1", "s2"), paste0("sample", 1:4))
+        ),
+        metadata=data.frame(
+            sample=paste0("sample", 1:4),
+            dataset=rep("d1", 4),
+            env=factor(c("A", "A", "B", "B"))
+        )
+    )
+    priors <- data.frame(env="A", prior=1)
+
+    expect_error(
+        calc.ess(
+            abd.meta,
+            pdata=priors,
+            prior_type="file",
+            env_column="env",
+            dset_column="dataset",
+            sample_column="sample",
+            which_envir="A",
+            error_to_file=FALSE
+        ),
+        "does not include retained environment"
+    )
+})
+
 test_that("quantile_normalize preserves prevalence phenotypes with NULL phenoP", {
     phenotype_results <- list(
         phenotype=c(taxon1=2, taxon2=1, taxon3=3),

--- a/package/phylogenize/tests/testthat/test-db-processing.R
+++ b/package/phylogenize/tests/testthat/test-db-processing.R
@@ -209,3 +209,48 @@ test_that("import.pz.db validates loaded taxonomy schema", {
         "Taxonomy file is missing required column"
     )
 })
+
+test_that("import.pz.db validates loaded gene function schema", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("db-function-schema-")
+    dir.create(tmp)
+    writeLines(c(
+        "database,genes,trees,taxonomy,functions",
+        "test-db,genes.rds,trees.rds,taxonomy.csv,functions.csv"
+    ), file.path(tmp, "databases.csv"))
+    saveRDS(
+        list(p1=Matrix::Matrix(
+            matrix(
+                c(1, 0),
+                nrow=1,
+                dimnames=list("gene1", c("s1", "s2"))
+            ),
+            sparse=TRUE
+        )),
+        file.path(tmp, "genes.rds")
+    )
+    saveRDS(
+        list(p1=ape::read.tree(text="(s1:1,s2:1);")),
+        file.path(tmp, "trees.rds")
+    )
+    writeLines(c(
+        "cluster,species,genus,family,order,class,phylum,domain",
+        "s1,s1,g1,f1,o1,c1,p1,d1",
+        "s2,s2,g1,f1,o1,c1,p1,d1"
+    ), file.path(tmp, "taxonomy.csv"))
+    writeLines(c(
+        "node_head,accession,description",
+        "gene1,acc1,fxn1"
+    ), file.path(tmp, "functions.csv"))
+
+    expect_error(
+        import.pz.db(
+            data_dir=tmp,
+            db="test-db",
+            error_to_file=FALSE
+        ),
+        "Gene function file is missing required column"
+    )
+})

--- a/package/phylogenize/tests/testthat/test-db-processing.R
+++ b/package/phylogenize/tests/testthat/test-db-processing.R
@@ -108,3 +108,104 @@ test_that("above_minimum_genes keeps genes with enough present and absent tips",
     expect_equal(rownames(filtered$TaxonA), "g_keep")
     expect_equal(colnames(filtered$TaxonA), c("s1", "s2", "s3"))
 })
+
+test_that("import.pz.db rejects missing database index", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    expect_error(
+        import.pz.db(
+            data_dir=tempdir(),
+            db="missing-db",
+            error_to_file=FALSE
+        ),
+        "Database index not found"
+    )
+})
+
+test_that("import.pz.db validates database index columns", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("db-index-")
+    dir.create(tmp)
+    writeLines(c(
+        "database,genes,trees,taxonomy",
+        "test-db,genes.rds,trees.rds,taxonomy.csv"
+    ), file.path(tmp, "databases.csv"))
+
+    expect_error(
+        import.pz.db(
+            data_dir=tmp,
+            db="test-db",
+            error_to_file=FALSE
+        ),
+        "missing required column"
+    )
+})
+
+test_that("import.pz.db validates referenced database files before loading", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("db-files-")
+    dir.create(tmp)
+    writeLines(c(
+        "database,genes,trees,taxonomy,functions",
+        "test-db,genes.rds,trees.rds,taxonomy.csv,functions.csv"
+    ), file.path(tmp, "databases.csv"))
+
+    expect_error(
+        import.pz.db(
+            data_dir=tmp,
+            db="test-db",
+            error_to_file=FALSE
+        ),
+        "Database file\\(s\\) not found"
+    )
+})
+
+test_that("import.pz.db validates loaded taxonomy schema", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("db-schema-")
+    dir.create(tmp)
+    writeLines(c(
+        "database,genes,trees,taxonomy,functions",
+        "test-db,genes.rds,trees.rds,taxonomy.csv,functions.csv"
+    ), file.path(tmp, "databases.csv"))
+    saveRDS(
+        list(p1=Matrix::Matrix(
+            matrix(
+                c(1, 0),
+                nrow=1,
+                dimnames=list("gene1", c("s1", "s2"))
+            ),
+            sparse=TRUE
+        )),
+        file.path(tmp, "genes.rds")
+    )
+    saveRDS(
+        list(p1=ape::read.tree(text="(s1:1,s2:1);")),
+        file.path(tmp, "trees.rds")
+    )
+    writeLines(c(
+        "cluster,species,genus,family,order,class,phylum",
+        "s1,s1,g1,f1,o1,c1,p1",
+        "s2,s2,g1,f1,o1,c1,p1"
+    ), file.path(tmp, "taxonomy.csv"))
+    writeLines(c(
+        "node_head,accession,function",
+        "gene1,acc1,fxn1"
+    ), file.path(tmp, "functions.csv"))
+
+    expect_error(
+        import.pz.db(
+            data_dir=tmp,
+            db="test-db",
+            error_to_file=FALSE
+        ),
+        "Taxonomy file is missing required column"
+    )
+})

--- a/package/phylogenize/tests/testthat/test-fileio.R
+++ b/package/phylogenize/tests/testthat/test-fileio.R
@@ -150,20 +150,23 @@ test_that("tabular import rejects nonnumeric abundance values", {
         "s4\td1\tB"
     ), metadata_file)
 
-    expect_error(
-        read.abd.metadata(
-            input_format="tabular",
-            abundance_file=abundance_file,
-            metadata_file=metadata_file,
-            sample_column="sample",
-            dset_column="dataset",
-            env_column="env",
-            which_envir="A",
-            which_phenotype="abundance",
-            categorical=TRUE,
-            error_to_file=FALSE
+    expect_warning(
+        expect_error(
+            read.abd.metadata(
+                input_format="tabular",
+                abundance_file=abundance_file,
+                metadata_file=metadata_file,
+                sample_column="sample",
+                dset_column="dataset",
+                env_column="env",
+                which_envir="A",
+                which_phenotype="abundance",
+                categorical=TRUE,
+                error_to_file=FALSE
+            ),
+            "nonnumeric value"
         ),
-        "nonnumeric value"
+        NA
     )
 })
 

--- a/package/phylogenize/tests/testthat/test-fileio.R
+++ b/package/phylogenize/tests/testthat/test-fileio.R
@@ -233,6 +233,53 @@ test_that("harmonization keeps metadata aligned to retained abundance columns", 
     expect_false("s5" %in% harmonized$metadata$sample)
 })
 
+test_that("continuous metadata rejects partially nonnumeric environment values", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    metadata <- data.frame(
+        sample=c("s1", "s2", "s3"),
+        dataset=c("d1", "d1", "d1"),
+        env=c("1.2", "bad", "3.4")
+    )
+
+    expect_error(
+        check.process.metadata(
+            metadata,
+            sample_column="sample",
+            dset_column="dataset",
+            env_column="env",
+            categorical=FALSE,
+            error_to_file=FALSE
+        ),
+        "nonnumeric value"
+    )
+})
+
+test_that("metadata rejects missing environment values", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    metadata <- data.frame(
+        sample=c("s1", "s2", "s3"),
+        dataset=c("d1", "d1", "d1"),
+        env=c("A", NA, "B")
+    )
+
+    expect_error(
+        check.process.metadata(
+            metadata,
+            sample_column="sample",
+            dset_column="dataset",
+            env_column="env",
+            which_envir="A",
+            categorical=TRUE,
+            error_to_file=FALSE
+        ),
+        "missing values"
+    )
+})
+
 test_that("BIOM import test documents optional external dependency", {
     skip("BIOM round-trip helper still depends on obsolete biom_dir/external biom tooling.")
 })

--- a/package/phylogenize/tests/testthat/test-fileio.R
+++ b/package/phylogenize/tests/testthat/test-fileio.R
@@ -167,6 +167,68 @@ test_that("tabular import rejects nonnumeric abundance values", {
     )
 })
 
+test_that("abundance sanity check rejects duplicate and blank identifiers", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    duplicate_taxa <- matrix(
+        c(1, 0, 0, 1),
+        nrow=2,
+        dimnames=list(c("sp1", " sp1 "), c("s1", "s2"))
+    )
+    expect_error(
+        sanity.check.abundance(duplicate_taxa, error_to_file=FALSE),
+        "duplicate taxon names"
+    )
+
+    blank_samples <- matrix(
+        c(1, 0, 0, 1),
+        nrow=2,
+        dimnames=list(c("sp1", "sp2"), c("s1", " "))
+    )
+    expect_error(
+        sanity.check.abundance(blank_samples, error_to_file=FALSE),
+        "blank or missing sample names"
+    )
+})
+
+test_that("metadata sanity check rejects duplicate and blank sample IDs", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    duplicate_samples <- data.frame(
+        sample=c("s1", " s1 "),
+        dataset=c("d1", "d1"),
+        env=c("A", "B")
+    )
+    expect_error(
+        sanity.check.metadata(
+            duplicate_samples,
+            sample_column="sample",
+            dset_column="dataset",
+            env_column="env",
+            error_to_file=FALSE
+        ),
+        "duplicate sample IDs"
+    )
+
+    blank_samples <- data.frame(
+        sample=c("s1", ""),
+        dataset=c("d1", "d1"),
+        env=c("A", "B")
+    )
+    expect_error(
+        sanity.check.metadata(
+            blank_samples,
+            sample_column="sample",
+            dset_column="dataset",
+            env_column="env",
+            error_to_file=FALSE
+        ),
+        "blank or missing sample IDs"
+    )
+})
+
 test_that("harmonization trims sample identifiers before matching", {
     old_opts <- pz.options()
     on.exit(do.call(pz.options, old_opts), add=TRUE)

--- a/package/phylogenize/tests/testthat/test-fileio.R
+++ b/package/phylogenize/tests/testthat/test-fileio.R
@@ -284,13 +284,15 @@ test_that("harmonization keeps metadata aligned to retained abundance columns", 
         )
     )
 
-    harmonized <- harmonize.abd.meta(
-        abd.meta,
-        sample_column="sample",
-        dset_column="dataset",
-        env_column="env",
-        which_phenotype="abundance",
-        error_to_file=FALSE
+    harmonized <- suppressWarnings(
+        harmonize.abd.meta(
+            abd.meta,
+            sample_column="sample",
+            dset_column="dataset",
+            env_column="env",
+            which_phenotype="abundance",
+            error_to_file=FALSE
+        )
     )
 
     expect_equal(harmonized$metadata$sample, colnames(harmonized$mtx))

--- a/package/phylogenize/tests/testthat/test-fileio.R
+++ b/package/phylogenize/tests/testthat/test-fileio.R
@@ -342,8 +342,60 @@ test_that("metadata rejects missing environment values", {
     )
 })
 
-test_that("BIOM import test documents optional external dependency", {
-    skip("BIOM round-trip helper still depends on obsolete biom_dir/external biom tooling.")
+test_that("BIOM import reads native BIOM with separate metadata", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempdir()
+    biom_file <- file.path(tmp, "native-abundance.biom")
+    metadata_file <- file.path(tmp, "native-metadata.tsv")
+    abd_meta <- list(
+        mtx=matrix(
+            c(1, 0, 2, 3,
+              0, 4, 1, 5),
+            nrow=2,
+            byrow=TRUE,
+            dimnames=list(c("sp1", "sp2"), paste0("s", 1:4))
+        ),
+        metadata=data.frame(
+            sample=paste0("s", 1:4),
+            dataset=c("d1", "d1", "d1", "d1"),
+            env=c("A", "A", "B", "B")
+        )
+    )
+
+    out <- phylogenize:::write.test.biom(
+        abd_meta,
+        overwrite=TRUE,
+        biom_file=biom_file,
+        metadata_file=metadata_file,
+        separate_metadata=TRUE,
+        error_to_file=FALSE
+    )
+
+    expect_equal(out, biom_file)
+    expect_true(file.exists(biom_file))
+    expect_true(file.exists(metadata_file))
+
+    observed <- read.abd.metadata(
+        input_format="biom",
+        biom_file=biom_file,
+        separate_metadata=TRUE,
+        metadata_file=metadata_file,
+        sample_column="sample",
+        dset_column="dataset",
+        env_column="env",
+        which_envir="A",
+        which_phenotype="abundance",
+        categorical=TRUE,
+        error_to_file=FALSE
+    )
+
+    expect_equal(rownames(observed$mtx), c("sp1", "sp2"))
+    expect_equal(colnames(observed$mtx), paste0("s", 1:4))
+    expect_equal(as.numeric(observed$mtx["sp1", ]), c(1, 0, 2, 3))
+    expect_equal(as.character(observed$metadata$sample), paste0("s", 1:4))
+    expect_true(is.factor(observed$metadata$env))
 })
 
 test_that("16S mapping test documents optional external reference data", {

--- a/package/phylogenize/tests/testthat/test-fisher-enrich.R
+++ b/package/phylogenize/tests/testthat/test-fisher-enrich.R
@@ -1,0 +1,44 @@
+test_that("legacy enrichment helpers unnest without tidyr warnings", {
+    sigs <- list(
+        TaxonA=list(strong=c("g1", "g2"))
+    )
+    signs <- list(
+        TaxonA=c(g1=1, g2=1, g3=-1, g4=1)
+    )
+    mappings <- list(
+        pathway=tibble::tibble(
+            gene=c("g1", "g3", "g4"),
+            term=c("term-a", "term-b", "term-a")
+        )
+    )
+
+    expect_warning(
+        enriched <- multi.enrich(sigs, signs, mappings),
+        NA
+    )
+
+    expect_s3_class(enriched, "data.frame")
+    expect_equal(enriched$taxon, c("TaxonA", "TaxonA"))
+    expect_equal(enriched$cutoff, c("strong", "strong"))
+    expect_named(enriched, c(
+        "taxon", "cutoff", "termset", "term", "data", "enr",
+        "enr.pval", "enr.estimate", "enr.overlap", "enr.qval"
+    ))
+})
+
+test_that("tbl.result.qvs unnests result rows without tidyr warnings", {
+    results <- tibble::tibble(
+        taxon=c("TaxonA", "TaxonA", "TaxonB"),
+        gene=c("g1", "g2", "g3"),
+        p.value=c(0.01, 0.20, 0.03)
+    )
+
+    expect_warning(
+        out <- tbl.result.qvs(results, method=function(x) p.adjust(x, "BH")),
+        NA
+    )
+
+    expect_equal(nrow(out), 3)
+    expect_equal(out$q.value[1:2], p.adjust(results$p.value[1:2], "BH"))
+    expect_equal(out$q.value[3], results$p.value[3])
+})

--- a/package/phylogenize/tests/testthat/test-install-data.R
+++ b/package/phylogenize/tests/testthat/test-install-data.R
@@ -1,0 +1,53 @@
+test_that("install_data validates source files and extensions", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    pz.options(error_to_file=FALSE)
+
+    extdata <- file.path(tempdir(), "install-data-validation")
+    dir.create(extdata, showWarnings=FALSE)
+
+    expect_error(
+        install_data(file.path(tempdir(), "missing.csv"), .extd_path=extdata),
+        "Data archive not found"
+    )
+
+    unsupported <- tempfile(fileext=".txt")
+    writeLines("not supported", unsupported)
+    expect_error(
+        install_data(unsupported, .extd_path=extdata),
+        "Unsupported data file extension"
+    )
+
+    source_csv <- tempfile(fileext=".csv")
+    writeLines("database,genes", source_csv)
+    expect_error(
+        install_data(source_csv, .extd_path=file.path(tempdir(), "missing-dir")),
+        "extdata directory not found"
+    )
+})
+
+test_that("install_data copies csv files and protects existing destinations", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    pz.options(error_to_file=FALSE)
+
+    extdata <- file.path(tempdir(), "install-data-copy")
+    dir.create(extdata, showWarnings=FALSE)
+    source_csv <- file.path(tempdir(), "test-database.csv")
+    writeLines(c("database,genes", "db-one,genes.rds"), source_csv)
+
+    installed <- install_data(source_csv, .extd_path=extdata)
+    expect_equal(installed, file.path(extdata, basename(source_csv)))
+    expect_equal(readLines(installed), c("database,genes", "db-one,genes.rds"))
+
+    writeLines(c("database,genes", "db-two,genes.rds"), source_csv)
+    expect_error(
+        install_data(source_csv, .extd_path=extdata),
+        "Destination file already exists"
+    )
+    expect_equal(readLines(installed), c("database,genes", "db-one,genes.rds"))
+
+    overwritten <- install_data(source_csv, force=TRUE, .extd_path=extdata)
+    expect_equal(overwritten, installed)
+    expect_equal(readLines(installed), c("database,genes", "db-two,genes.rds"))
+})

--- a/package/phylogenize/tests/testthat/test-invoke.R
+++ b/package/phylogenize/tests/testthat/test-invoke.R
@@ -155,6 +155,88 @@ test_that("phylogenize_core returns a stable result object shape", {
     expect_equal(core$options("core_method"), "lm")
 })
 
+test_that("phylogenize_core preserves deterministic golden association results", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    set.seed(20240619)
+    tips <- paste0("sp", seq_len(30))
+    phenotype <- seq(-1.5, 1.5, length.out=length(tips))
+    names(phenotype) <- tips
+    high_phenotype <- phenotype >= stats::median(phenotype)
+    gene_presence <- matrix(
+        c(as.integer(high_phenotype), as.integer(!high_phenotype)),
+        nrow=2,
+        byrow=TRUE,
+        dimnames=list(c("g_pos", "g_neg"), tips)
+    )
+    pz_db <- list(
+        ntaxa=1,
+        species=list(TestTaxon=tips),
+        trees=list(TestTaxon=ape::rtree(length(tips), tip.label=tips)),
+        gene.presence=list(TestTaxon=gene_presence),
+        gene.to.fxn=tibble::tibble(
+            gene=rownames(gene_presence),
+            accession=c("K00001", "K00002"),
+            `function`=c("positive fixture gene", "negative fixture gene")
+        )
+    )
+
+    testthat::local_mocked_bindings(
+        data_to_phenotypes=function(save_data=FALSE, ...) {
+            list(
+                phenotype_results=list(phenotype=phenotype),
+                pz.db=pz_db
+            )
+        },
+        .package="phylogenize"
+    )
+
+    core <- phylogenize_core(
+        do_enr=FALSE,
+        p.method=lm.fx.pv,
+        core_method="lm",
+        min_fx=0,
+        minimum=3,
+        out_dir=tempdir(),
+        error_to_file=FALSE,
+        verbosity=0
+    )
+    results_matrix <- core$list_signif$results.matrix
+
+    expect_equal(results_matrix$taxon, c("TestTaxon", "TestTaxon"))
+    expect_equal(results_matrix$gene, c("g_pos", "g_neg"))
+    expect_equal(
+        unname(results_matrix$effect.size),
+        c(1.55172413793103, -1.55172413793103),
+        tolerance=1e-12
+    )
+    expect_equal(
+        unname(results_matrix$p.value),
+        rep(6.065437457762578e-10, 2),
+        tolerance=1e-15
+    )
+    expect_equal(
+        unname(results_matrix$std.err),
+        rep(0.168930327088495, 2),
+        tolerance=1e-12
+    )
+    expect_equal(unname(results_matrix$df), c(28, 28))
+    expect_equal(
+        unname(results_matrix$q.value),
+        rep(6.065437457762578e-10, 2),
+        tolerance=1e-15
+    )
+    expect_equal(core$list_signif$signif$TestTaxon$strong,
+                 c("g_pos", "g_neg"))
+    expect_equal(core$list_signif$pos.sig$TestTaxon, "g_pos")
+    expect_equal(core$list_signif$neg.sig$TestTaxon, "g_neg")
+    expect_equal(core$list_signif$pos.sig.thresh$TestTaxon, "g_pos")
+    expect_equal(core$list_signif$neg.sig.thresh$TestTaxon, "g_neg")
+    expect_equal(core$list_signif$phy.with.pos.sigs, "TestTaxon")
+    expect_equal(core$list_signif$phy.with.neg.sigs, "TestTaxon")
+})
+
 test_that("phylogenize_core creates configured output directory", {
     old_opts <- pz.options()
     on.exit(do.call(pz.options, old_opts), add=TRUE)

--- a/package/phylogenize/tests/testthat/test-invoke.R
+++ b/package/phylogenize/tests/testthat/test-invoke.R
@@ -66,6 +66,95 @@ test_that("phylogenize_core skips enrichment when associations return NULL", {
     expect_false(seen$enrichment_called)
 })
 
+test_that("phylogenize_core returns a stable result object shape", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    set.seed(20240618)
+    tips <- paste0("sp", seq_len(30))
+    phenotype <- seq(-1.5, 1.5, length.out=length(tips))
+    names(phenotype) <- tips
+    high_phenotype <- phenotype >= stats::median(phenotype)
+    gene_presence <- matrix(
+        c(as.integer(high_phenotype), as.integer(!high_phenotype)),
+        nrow=2,
+        byrow=TRUE,
+        dimnames=list(c("g_pos", "g_neg"), tips)
+    )
+    pz_db <- list(
+        ntaxa=1,
+        species=list(TestTaxon=tips),
+        trees=list(TestTaxon=ape::rtree(length(tips), tip.label=tips)),
+        gene.presence=list(TestTaxon=gene_presence),
+        gene.to.fxn=tibble::tibble(
+            gene=rownames(gene_presence),
+            accession=c("K00001", "K00002"),
+            `function`=c("positive fixture gene", "negative fixture gene")
+        )
+    )
+    out_dir <- file.path(tempdir(), "phylogenize-core-shape-test")
+
+    testthat::local_mocked_bindings(
+        data_to_phenotypes=function(save_data=FALSE, ...) {
+            list(
+                phenotype_results=list(phenotype=phenotype),
+                pz.db=pz_db
+            )
+        },
+        get_enrichment_tbls=function(...) {
+            tibble::tibble(
+                taxon="TestTaxon",
+                term="mock_term",
+                enr.qval=0.01,
+                enr.pval=0.001
+            )
+        },
+        .package="phylogenize"
+    )
+
+    core <- phylogenize_core(
+        do_enr=TRUE,
+        p.method=lm.fx.pv,
+        core_method="lm",
+        min_fx=0,
+        minimum=3,
+        out_dir=out_dir,
+        error_to_file=FALSE,
+        verbosity=0
+    )
+
+    expect_named(core, c("list_pheno", "list_signif", "enr_tbls", "options"))
+    expect_named(core$list_pheno, c("phenotype_results", "pz.db"))
+    expect_equal(names(core$list_pheno$phenotype_results$phenotype), tips)
+    expect_equal(core$list_pheno$pz.db$ntaxa, 1)
+    expect_named(core$list_signif, c(
+        "results", "signif", "signs", "pos.sig", "results.matrix",
+        "phy.with.sigs", "pos.sig.descs", "pos.sig.thresh",
+        "pos.sig.thresh.descs", "neg.sig", "neg.sig.descs",
+        "neg.sig.thresh", "neg.sig.thresh.descs", "phy.with.pos.sigs",
+        "phy.with.neg.sigs"
+    ))
+    expect_named(core$list_signif$results, "TestTaxon")
+    expect_equal(rownames(core$list_signif$results$TestTaxon),
+                 c("Estimate", "p.value", "StdErr", "df"))
+    expect_equal(colnames(core$list_signif$results$TestTaxon),
+                 c("g_pos", "g_neg"))
+    expect_equal(nrow(core$list_signif$results.matrix), 2)
+    expect_equal(
+        names(core$list_signif$results.matrix),
+        c("taxon", "gene", "effect.size", "p.value", "std.err", "df",
+          "q.value")
+    )
+    expect_setequal(core$list_signif$results.matrix$gene, c("g_pos", "g_neg"))
+    expect_equal(core$list_signif$phy.with.pos.sigs, "TestTaxon")
+    expect_equal(core$list_signif$phy.with.neg.sigs, "TestTaxon")
+    expect_s3_class(core$enr_tbls, "tbl_df")
+    expect_equal(nrow(core$enr_tbls), 1)
+    expect_equal(core$options("out_dir"),
+                 normalizePath(out_dir, mustWork=FALSE))
+    expect_equal(core$options("core_method"), "lm")
+})
+
 test_that("phylogenize_core creates configured output directory", {
     old_opts <- pz.options()
     on.exit(do.call(pz.options, old_opts), add=TRUE)

--- a/package/phylogenize/tests/testthat/test-invoke.R
+++ b/package/phylogenize/tests/testthat/test-invoke.R
@@ -56,9 +56,12 @@ test_that("phylogenize_core skips enrichment when associations return NULL", {
         .package="phylogenize"
     )
 
-    core <- phylogenize_core(
-        do_enr=TRUE,
-        error_to_file=FALSE
+    expect_warning(
+        core <- phylogenize_core(
+            do_enr=TRUE,
+            error_to_file=FALSE
+        ),
+        "Association testing returned no results"
     )
 
     expect_null(core$list_signif)

--- a/package/phylogenize/tests/testthat/test-options-isolation.R
+++ b/package/phylogenize/tests/testthat/test-options-isolation.R
@@ -30,3 +30,42 @@ test_that("resolved option objects remain isolated from later global changes", {
                  p.adjust(c(0.01, 0.02, 0.50), "BY"))
     expect_equal(pz.options("out_dir"), "global-run")
 })
+
+test_that("packaged database index loads without readr warnings", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    pz.options(data_dir="", error_to_file=FALSE)
+
+    expect_warning(
+        expect_message(
+            check_data_found(startup=FALSE),
+            "Databases listed:"
+        ),
+        NA
+    )
+    expect_true(dir.exists(pz.options("data_dir")))
+})
+
+test_that("database index validation catches malformed files", {
+    bad_index <- tempfile(fileext=".csv")
+    writeLines(c(
+        "genes,trees",
+        "genes.rds,tree.rds"
+    ), bad_index)
+
+    expect_error(
+        phylogenize:::read.internal.database.index(bad_index),
+        "missing required column"
+    )
+
+    blank_index <- tempfile(fileext=".csv")
+    writeLines(c(
+        "database,genes,trees",
+        ",genes.rds,tree.rds"
+    ), blank_index)
+
+    expect_error(
+        phylogenize:::read.internal.database.index(blank_index),
+        "blank database names"
+    )
+})

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -128,6 +128,31 @@ test_that("run.vsearch validates executable and input files", {
         ),
         "query FASTA not found"
     )
+
+    expect_error(
+        run.vsearch(
+            vsearch_dir=fake_vsearch,
+            data_dir=tmp,
+            vsearch_16sfile="missing-db.fna",
+            named_asv_file=query_file,
+            vsearch_outfile=file.path(tmp, "hits.tsv"),
+            error_to_file=FALSE
+        ),
+        "reference FASTA not found"
+    )
+
+    expect_error(
+        run.vsearch(
+            vsearch_dir=fake_vsearch,
+            data_dir=tmp,
+            vsearch_16sfile="db.fna",
+            named_asv_file=query_file,
+            vsearch_cutoff=1.5,
+            vsearch_outfile=file.path(tmp, "hits.tsv"),
+            error_to_file=FALSE
+        ),
+        "vsearch_cutoff must be"
+    )
 })
 
 test_that("get.vsearch.results rejects malformed vsearch output", {

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -2,23 +2,34 @@ test_that("run.vsearch passes strand option as separate arguments", {
     old_opts <- pz.options()
     on.exit(do.call(pz.options, old_opts), add=TRUE)
 
-    tmp <- tempdir()
+    tmp <- tempfile("vsearch-")
+    dir.create(tmp)
     capture_file <- file.path(tmp, "vsearch-args.txt")
-    fake_vsearch <- file.path(tmp, "fake-vsearch")
+    fake_bindir <- file.path(tmp, "bin")
+    dir.create(fake_bindir)
+    fake_vsearch <- file.path(fake_bindir, "vsearch")
+    query_file <- file.path(tmp, "input.fna")
+    db_file <- file.path(tmp, "db.fna")
+    hits_file <- file.path(tmp, "hits.tsv")
+    writeLines(c(">Row1", "ACGT"), query_file)
+    writeLines(c(">ref;;genus;;species_a", "ACGT"), db_file)
     writeLines(c(
         "#!/bin/sh",
         sprintf("printf '%%s\\n' \"$@\" > %s", shQuote(capture_file)),
+        "last_arg=''",
+        "for arg in \"$@\"; do last_arg=\"$arg\"; done",
+        "touch \"$last_arg\"",
         "exit 0"
     ), fake_vsearch)
     Sys.chmod(fake_vsearch, mode="0755")
 
     expect_true(run.vsearch(
-        vsearch_dir=fake_vsearch,
+        vsearch_dir=fake_bindir,
         data_dir=tmp,
         vsearch_16sfile="db.fna",
-        named_asv_file="input.fna",
+        named_asv_file=query_file,
         vsearch_cutoff=0.985,
-        vsearch_outfile="hits.tsv",
+        vsearch_outfile=hits_file,
         error_to_file=FALSE
     ))
 
@@ -28,6 +39,7 @@ test_that("run.vsearch passes strand option as separate arguments", {
     expect_false("--strand both" %in% args)
     expect_false(is.na(strand_idx))
     expect_equal(args[strand_idx + 1], "both")
+    expect_true(file.exists(hits_file))
 })
 
 test_that("16S helpers can use resolved options without global mutation", {
@@ -77,4 +89,87 @@ test_that("16S helpers can use resolved options without global mutation", {
     expect_equal(pz.options("named_asv_file"), global_asv_file)
     expect_equal(pz.options("vsearch_outfile"), global_hits_file)
     expect_equal(pz.options("min_frac_16s"), 1)
+})
+
+test_that("run.vsearch validates executable and input files", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("vsearch-validation-")
+    dir.create(tmp)
+    query_file <- file.path(tmp, "input.fna")
+    db_file <- file.path(tmp, "db.fna")
+    fake_vsearch <- file.path(tmp, "vsearch")
+    writeLines(c(">Row1", "ACGT"), query_file)
+    writeLines(c(">ref;;genus;;species_a", "ACGT"), db_file)
+    writeLines(c("#!/bin/sh", "exit 0"), fake_vsearch)
+
+    expect_error(
+        run.vsearch(
+            vsearch_dir=fake_vsearch,
+            data_dir=tmp,
+            vsearch_16sfile="db.fna",
+            named_asv_file=query_file,
+            vsearch_outfile=file.path(tmp, "hits.tsv"),
+            error_to_file=FALSE
+        ),
+        "not runnable"
+    )
+
+    Sys.chmod(fake_vsearch, mode="0755")
+    expect_error(
+        run.vsearch(
+            vsearch_dir=fake_vsearch,
+            data_dir=tmp,
+            vsearch_16sfile="db.fna",
+            named_asv_file=file.path(tmp, "missing.fna"),
+            vsearch_outfile=file.path(tmp, "hits.tsv"),
+            error_to_file=FALSE
+        ),
+        "query FASTA not found"
+    )
+})
+
+test_that("get.vsearch.results rejects malformed vsearch output", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("vsearch-output-")
+    dir.create(tmp)
+    hits_file <- file.path(tmp, "hits.tsv")
+
+    expect_error(
+        get.vsearch.results(
+            vsearch_outfile=hits_file,
+            error_to_file=FALSE
+        ),
+        "output file not found"
+    )
+
+    writeLines("bad_query\tref;;genus;;species_a\t99", hits_file)
+    expect_error(
+        get.vsearch.results(
+            vsearch_outfile=hits_file,
+            error_to_file=FALSE
+        ),
+        "invalid query ID"
+    )
+
+    writeLines("Row1\tmalformed_target\t99", hits_file)
+    expect_error(
+        get.vsearch.results(
+            vsearch_outfile=hits_file,
+            error_to_file=FALSE
+        ),
+        "malformed target ID"
+    )
+
+    writeLines("Row1\tref;;genus;;species_a\tbad", hits_file)
+    expect_error(
+        get.vsearch.results(
+            vsearch_outfile=hits_file,
+            error_to_file=FALSE
+        ),
+        "nonnumeric percent identity"
+    )
 })

--- a/package/phylogenize/tests/testthat/test-report-functions.R
+++ b/package/phylogenize/tests/testthat/test-report-functions.R
@@ -7,7 +7,7 @@ test_that("non.interactive.plot adds an explicit visible branch layer", {
         lims=c(0, 2)
     )
 
-    p <- non.interactive.plot(tree.obj)
+    p <- suppressWarnings(non.interactive.plot(tree.obj))
     layer_colors <- vapply(p$layers, function(layer) {
         color <- layer$aes_params[["colour"]]
         if (is.null(color)) color <- layer$aes_params[["color"]]

--- a/package/phylogenize/tests/testthat/test-report-render.R
+++ b/package/phylogenize/tests/testthat/test-report-render.R
@@ -50,3 +50,20 @@ test_that("render_core_report renders a minimal partial-result report", {
 
     expect_true(file.exists(output))
 })
+
+test_that("render_core_report rejects missing report templates", {
+    core <- list(
+        list_pheno=list(),
+        list_signif=NULL
+    )
+
+    expect_error(
+        render_core_report(
+            core,
+            report_input="missing-report-template.Rmd",
+            out_dir=tempdir(),
+            error_to_file=FALSE
+        ),
+        "Report template not found"
+    )
+})

--- a/package/phylogenize/tests/testthat/test-significance-helpers.R
+++ b/package/phylogenize/tests/testthat/test-significance-helpers.R
@@ -104,6 +104,85 @@ test_that("qvals validates methods and p-values", {
     )
 })
 
+test_that("FDR method snapshots preserve q-values, names, and missingness", {
+    p <- c(
+        g_strong=0.001,
+        g_mid=0.020,
+        g_border=0.049,
+        g_null=0.200,
+        g_missing=NA_real_,
+        g_high=0.800
+    )
+    expected_bh <- c(
+        g_strong=0.00500000,
+        g_mid=0.05000000,
+        g_border=0.0816666666666667,
+        g_null=0.25000000,
+        g_missing=NA_real_,
+        g_high=0.80000000
+    )
+    expected_by <- c(
+        g_strong=0.0114166666666667,
+        g_mid=0.1141666666666667,
+        g_border=0.1864722222222222,
+        g_null=0.5708333333333333,
+        g_missing=NA_real_,
+        g_high=1.00000000
+    )
+
+    observed_bh <- phylogenize:::qvals(p, fdr_method="BH",
+                                       error_to_file=FALSE)
+    observed_by <- phylogenize:::qvals(p, fdr_method="BY",
+                                       error_to_file=FALSE)
+    expect_warning(
+        observed_qvalue <- phylogenize:::qvals(p, fdr_method="qvalue",
+                                               error_to_file=FALSE),
+        "Trying lambda=0"
+    )
+
+    expect_named(observed_bh, names(p))
+    expect_named(observed_by, names(p))
+    expect_named(observed_qvalue, names(p))
+    expect_equal(observed_bh, expected_bh, tolerance=1e-8)
+    expect_equal(observed_by, expected_by, tolerance=1e-8)
+    expect_equal(observed_qvalue, expected_bh, tolerance=1e-8)
+    expect_true(is.na(observed_bh[["g_missing"]]))
+    expect_true(is.na(observed_by[["g_missing"]]))
+    expect_true(is.na(observed_qvalue[["g_missing"]]))
+})
+
+test_that("FDR method choice changes significant hits on fixed result objects", {
+    results <- list(
+        TaxonFDR=matrix(
+            c(1.5, 1.2, -1.1, 0.8,
+              0.001, 0.020, 0.049, 0.200,
+              0.10, 0.10, 0.10, 0.10,
+              20.0, 20.0, 20.0, 20.0),
+            nrow=4,
+            byrow=TRUE,
+            dimnames=list(
+                c("Estimate", "p.value", "StdErr", "df"),
+                c("g_strong", "g_mid", "g_border", "g_null")
+            )
+        )
+    )
+    cuts <- c(strong=0.05)
+    opts_bh <- pz.resolve.options(fdr_method="BH", error_to_file=FALSE)
+    opts_by <- pz.resolve.options(fdr_method="BY", error_to_file=FALSE)
+
+    sigs_bh <- make.sigs(results, cuts=cuts, min.fx=0, .opts=opts_bh)
+    sigs_by <- make.sigs(results, cuts=cuts, min.fx=0, .opts=opts_by)
+    signs <- list(
+        TaxonFDR=c(g_strong=1, g_mid=1, g_border=-1, g_null=1)
+    )
+
+    expect_equal(sigs_bh$TaxonFDR$strong, c("g_strong", "g_mid"))
+    expect_equal(sigs_by$TaxonFDR$strong, "g_strong")
+    expect_equal(make.pos.sig(sigs_bh, signs)$TaxonFDR,
+                 c("g_strong", "g_mid"))
+    expect_equal(make.pos.sig(sigs_by, signs)$TaxonFDR, "g_strong")
+})
+
 test_that("calc.alpha.power compares named rejected tests to named truth sets", {
     pvs <- c(g_null=0.01, g_alt=0.02, g_miss=0.50, g_alt2=0.20)
 

--- a/package/phylogenize/tests/testthat/test-significance-helpers.R
+++ b/package/phylogenize/tests/testthat/test-significance-helpers.R
@@ -19,6 +19,27 @@ test_that("make.results.matrix converts result matrices to long rows", {
     expect_equal(as.numeric(result_tbl$p.value), c(0.01, 0.20))
 })
 
+test_that("add.sig.descs annotates genes without tidyr warnings", {
+    sigs <- list(
+        TaxonA=c("g1", "g2"),
+        TaxonB="g3"
+    )
+    gene_to_fxn <- tibble::tibble(
+        gene=c("g1", "g2", "g3"),
+        accession=c("K00001", "K00002", "K00003"),
+        `function`=c("first gene", "second gene", "third gene")
+    )
+
+    expect_warning(
+        out <- add.sig.descs(c("TaxonA", "TaxonB"), sigs, gene_to_fxn),
+        NA
+    )
+
+    expect_equal(out$taxon, c("TaxonA", "TaxonA", "TaxonB"))
+    expect_equal(out$gene, c("g1", "g2", "g3"))
+    expect_equal(out$description, gene_to_fxn$`function`)
+})
+
 test_that("qvals uses configured p.adjust methods", {
     old_opts <- pz.options()
     on.exit(do.call(pz.options, old_opts), add=TRUE)

--- a/package/phylogenize/tests/testthat/test-significance-helpers.R
+++ b/package/phylogenize/tests/testthat/test-significance-helpers.R
@@ -172,10 +172,10 @@ test_that("FDR method choice changes significant hits on fixed result objects", 
 
     sigs_bh <- make.sigs(results, cuts=cuts, min.fx=0, .opts=opts_bh)
     sigs_by <- make.sigs(results, cuts=cuts, min.fx=0, .opts=opts_by)
-    signs <- list(
-        TaxonFDR=c(g_strong=1, g_mid=1, g_border=-1, g_null=1)
-    )
+    signs <- make.signs(results)
 
+    expect_named(signs$TaxonFDR,
+                 c("g_strong", "g_mid", "g_border", "g_null"))
     expect_equal(sigs_bh$TaxonFDR$strong, c("g_strong", "g_mid"))
     expect_equal(sigs_by$TaxonFDR$strong, "g_strong")
     expect_equal(make.pos.sig(sigs_bh, signs)$TaxonFDR,

--- a/package/phylogenize/tests/testthat/test-significance-helpers.R
+++ b/package/phylogenize/tests/testthat/test-significance-helpers.R
@@ -58,6 +58,13 @@ test_that("qvals validates methods and p-values", {
     expect_equal(observed[c("g1", "g3")], p.adjust(p[c("g1", "g3")], "BH"))
     expect_equal(phylogenize:::qvals(numeric(0), fdr_method="BH"),
                  numeric(0))
+    matrix_p <- matrix(
+        0.01,
+        nrow=1,
+        dimnames=list("p.value", "g_matrix")
+    )
+    expect_equal(names(phylogenize:::qvals(matrix_p, fdr_method="BH")),
+                 "g_matrix")
 
     expect_error(
         phylogenize:::qvals(c(0.01, 0.02), fdr_method="bonferroni",

--- a/package/phylogenize/tests/testthat/test-significance-helpers.R
+++ b/package/phylogenize/tests/testthat/test-significance-helpers.R
@@ -46,6 +46,31 @@ test_that("qvals can use resolved options without global mutation", {
     expect_equal(phylogenize:::qvals(p, .opts=opts), p.adjust(p, "BY"))
 })
 
+test_that("qvals validates methods and p-values", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    p <- c(g1=0.01, g2=NA, g3=0.50)
+    observed <- phylogenize:::qvals(p, fdr_method="BH", error_to_file=FALSE)
+
+    expect_equal(names(observed), names(p))
+    expect_true(is.na(observed[["g2"]]))
+    expect_equal(observed[c("g1", "g3")], p.adjust(p[c("g1", "g3")], "BH"))
+    expect_equal(phylogenize:::qvals(numeric(0), fdr_method="BH"),
+                 numeric(0))
+
+    expect_error(
+        phylogenize:::qvals(c(0.01, 0.02), fdr_method="bonferroni",
+                            error_to_file=FALSE),
+        "Invalid fdr_method"
+    )
+    expect_error(
+        phylogenize:::qvals(c(0.01, 1.2), fdr_method="BH",
+                            error_to_file=FALSE),
+        "p-values must be finite"
+    )
+})
+
 test_that("calc.alpha.power compares named rejected tests to named truth sets", {
     pvs <- c(g_null=0.01, g_alt=0.02, g_miss=0.50, g_alt2=0.20)
 

--- a/package/phylogenize/tests/testthat/test-significance-helpers.R
+++ b/package/phylogenize/tests/testthat/test-significance-helpers.R
@@ -56,6 +56,11 @@ test_that("qvals validates methods and p-values", {
     expect_equal(names(observed), names(p))
     expect_true(is.na(observed[["g2"]]))
     expect_equal(observed[c("g1", "g3")], p.adjust(p[c("g1", "g3")], "BH"))
+    all_missing <- c(g1=NA_real_, g2=NA_real_)
+    missing_observed <- phylogenize:::qvals(all_missing, fdr_method="BH",
+                                            error_to_file=FALSE)
+    expect_equal(names(missing_observed), names(all_missing))
+    expect_true(all(is.na(missing_observed)))
     expect_equal(phylogenize:::qvals(numeric(0), fdr_method="BH"),
                  numeric(0))
     matrix_p <- matrix(

--- a/package/phylogenize/tests/testthat/test-statistical-calibration.R
+++ b/package/phylogenize/tests/testthat/test-statistical-calibration.R
@@ -44,3 +44,65 @@ test_that("null association p-values are not inflated under independent data", {
     expect_gt(stats::ks.test(p_values, "punif")$p.value, 0.01)
     expect_equal(sum(q_values < 0.05), 0)
 })
+
+test_that("association statistics are invariant to tree and matrix ordering", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    set.seed(20240615)
+
+    n_taxa <- 40
+    n_genes <- 12
+    taxa <- paste0("taxon", seq_len(n_taxa))
+    genes <- paste0("gene", seq_len(n_genes))
+    phenotype <- stats::rnorm(n_taxa)
+    names(phenotype) <- taxa
+    gene_presence <- matrix(
+        stats::rbinom(n_taxa * n_genes, 1, 0.45),
+        nrow=n_genes,
+        dimnames=list(genes, taxa)
+    )
+    keep <- rowSums(gene_presence) > 3 &
+        rowSums(gene_presence) < (n_taxa - 3)
+    gene_presence <- gene_presence[keep, , drop=FALSE]
+    tree <- ape::rtree(n_taxa, tip.label=taxa)
+    opts <- pz.resolve.options(
+        core_method="lm",
+        separate_process=FALSE,
+        meas_err=FALSE,
+        error_to_file=FALSE
+    )
+    run_assoc <- function(tr, genes_by_taxa, pheno) {
+        matrix.plm(
+            tr,
+            genes_by_taxa,
+            pheno,
+            method=lm.fx.pv,
+            restrict.taxa=intersect(colnames(genes_by_taxa), tr$tip.label),
+            restrict.ff=rownames(genes_by_taxa),
+            .opts=opts
+        )
+    }
+
+    baseline <- run_assoc(tree, gene_presence, phenotype)
+    permuted_gene_presence <- gene_presence[
+        sample(rownames(gene_presence)),
+        sample(colnames(gene_presence)),
+        drop=FALSE
+    ]
+    permuted_phenotype <- phenotype[sample(names(phenotype))]
+    permuted_tree <- ape::keep.tip(tree, sample(tree$tip.label))
+    permuted <- run_assoc(
+        permuted_tree,
+        permuted_gene_presence,
+        permuted_phenotype
+    )
+
+    expect_equal(rownames(permuted), rownames(baseline))
+    expect_setequal(colnames(permuted), colnames(baseline))
+    expect_equal(
+        permuted[, colnames(baseline), drop=FALSE],
+        baseline,
+        tolerance=1e-12,
+        ignore_attr=TRUE
+    )
+})

--- a/package/phylogenize/tests/testthat/test-statistical-calibration.R
+++ b/package/phylogenize/tests/testthat/test-statistical-calibration.R
@@ -1,0 +1,46 @@
+test_that("null association p-values are not inflated under independent data", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    set.seed(20240614)
+
+    n_taxa <- 80
+    n_genes <- 120
+    taxa <- paste0("taxon", seq_len(n_taxa))
+    genes <- paste0("gene", seq_len(n_genes))
+    phenotype <- stats::rnorm(n_taxa)
+    names(phenotype) <- taxa
+
+    gene_rows <- replicate(
+        n_genes,
+        sample(rep(c(FALSE, TRUE), each=n_taxa / 2)),
+        simplify=FALSE
+    )
+    gene_presence <- do.call(rbind, gene_rows)
+    rownames(gene_presence) <- genes
+    colnames(gene_presence) <- taxa
+    tree <- ape::rtree(n_taxa, tip.label=taxa)
+    opts <- pz.resolve.options(
+        core_method="lm",
+        separate_process=FALSE,
+        meas_err=FALSE,
+        error_to_file=FALSE
+    )
+
+    result <- matrix.plm(
+        tree,
+        gene_presence,
+        phenotype,
+        method=lm.fx.pv,
+        restrict.taxa=taxa,
+        restrict.ff=genes,
+        .opts=opts
+    )
+    p_values <- as.numeric(result["p.value", ])
+    q_values <- p.adjust(p_values, method="BH")
+
+    expect_true(all(is.finite(p_values)))
+    expect_true(all(p_values >= 0 & p_values <= 1))
+    expect_lte(mean(p_values < 0.05), 0.10)
+    expect_gt(stats::ks.test(p_values, "punif")$p.value, 0.01)
+    expect_equal(sum(q_values < 0.05), 0)
+})

--- a/package/phylogenize/tests/testthat/test-statistical-calibration.R
+++ b/package/phylogenize/tests/testthat/test-statistical-calibration.R
@@ -106,3 +106,59 @@ test_that("association statistics are invariant to tree and matrix ordering", {
         ignore_attr=TRUE
     )
 })
+
+test_that("known synthetic signals rank above null genes", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    set.seed(20240616)
+
+    n_taxa <- 80
+    n_null <- 30
+    taxa <- paste0("taxon", seq_len(n_taxa))
+    latent <- seq(-2, 2, length.out=n_taxa)
+    phenotype <- latent + stats::rnorm(n_taxa, sd=0.25)
+    names(phenotype) <- taxa
+    high_phenotype <- phenotype >= stats::median(phenotype)
+    null_rows <- replicate(
+        n_null,
+        sample(rep(c(0, 1), each=n_taxa / 2)),
+        simplify=FALSE
+    )
+    gene_presence <- rbind(
+        causal_positive=as.integer(high_phenotype),
+        causal_negative=as.integer(!high_phenotype),
+        do.call(rbind, null_rows)
+    )
+    rownames(gene_presence)[-(1:2)] <- paste0("null", seq_len(n_null))
+    colnames(gene_presence) <- taxa
+    tree <- ape::rtree(n_taxa, tip.label=taxa)
+    opts <- pz.resolve.options(
+        core_method="lm",
+        separate_process=FALSE,
+        meas_err=FALSE,
+        fdr_method="BH",
+        error_to_file=FALSE
+    )
+
+    result <- matrix.plm(
+        tree,
+        gene_presence,
+        phenotype,
+        method=lm.fx.pv,
+        restrict.taxa=taxa,
+        restrict.ff=rownames(gene_presence),
+        .opts=opts
+    )
+    p_values <- result["p.value", ]
+    q_values <- phylogenize:::qvals(p_values, .opts=opts)
+    effects <- result["Estimate", ]
+    causal_genes <- c("causal_positive", "causal_negative")
+    null_genes <- paste0("null", seq_len(n_null))
+
+    expect_setequal(names(sort(p_values))[1:2], causal_genes)
+    expect_gt(effects[["causal_positive"]], 0)
+    expect_lt(effects[["causal_negative"]], 0)
+    expect_true(all(q_values[causal_genes] < 0.05))
+    expect_equal(sum(q_values[null_genes] < 0.05), 0)
+    expect_lt(max(q_values[causal_genes]), min(q_values[null_genes]))
+})

--- a/package/phylogenize/tests/testthat/test-statistical-calibration.R
+++ b/package/phylogenize/tests/testthat/test-statistical-calibration.R
@@ -162,3 +162,68 @@ test_that("known synthetic signals rank above null genes", {
     expect_equal(sum(q_values[null_genes] < 0.05), 0)
     expect_lt(max(q_values[causal_genes]), min(q_values[null_genes]))
 })
+
+test_that("deterministic association methods agree on core signal invariants", {
+    testthat::skip_if_not_installed("phylolm")
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    set.seed(20240617)
+
+    n_taxa <- 60
+    n_null <- 8
+    taxa <- paste0("taxon", seq_len(n_taxa))
+    latent <- seq(-2, 2, length.out=n_taxa)
+    phenotype <- latent + stats::rnorm(n_taxa, sd=0.2)
+    names(phenotype) <- taxa
+    high_phenotype <- phenotype >= stats::median(phenotype)
+    null_rows <- replicate(
+        n_null,
+        sample(rep(c(0, 1), each=n_taxa / 2)),
+        simplify=FALSE
+    )
+    gene_presence <- rbind(
+        causal_positive=as.integer(high_phenotype),
+        do.call(rbind, null_rows)
+    )
+    rownames(gene_presence)[-1] <- paste0("null", seq_len(n_null))
+    colnames(gene_presence) <- taxa
+    tree <- ape::rtree(n_taxa, tip.label=taxa)
+    opts <- pz.resolve.options(
+        separate_process=FALSE,
+        meas_err=FALSE,
+        error_to_file=FALSE
+    )
+    methods <- list(
+        lm=lm.fx.pv,
+        phylolm=phylolm.fx.pv
+    )
+
+    results <- lapply(methods, function(method) {
+        matrix.plm(
+            tree,
+            gene_presence,
+            phenotype,
+            method=method,
+            restrict.taxa=taxa,
+            restrict.ff=rownames(gene_presence),
+            .opts=opts
+        )
+    })
+
+    expect_equal(lapply(results, rownames), stats::setNames(
+        rep(list(c("Estimate", "p.value", "StdErr", "df")),
+            length(results)),
+        names(results)
+    ))
+    expect_equal(lapply(results, colnames), stats::setNames(
+        rep(list(rownames(gene_presence)), length(results)),
+        names(results)
+    ))
+    for (method_name in names(results)) {
+        result <- results[[method_name]]
+        expect_true(all(is.finite(result[, "causal_positive"])))
+        expect_gt(result["Estimate", "causal_positive"], 0)
+        expect_lt(result["p.value", "causal_positive"], 0.05)
+        expect_equal(names(sort(result["p.value", ]))[1], "causal_positive")
+    }
+})

--- a/package/phylogenize/tests/testthat/test-trees.R
+++ b/package/phylogenize/tests/testthat/test-trees.R
@@ -1,0 +1,21 @@
+test_that("fix.tree repairs missing and invalid branch lengths", {
+    no_lengths <- ape::read.tree(text="(s1,s2,(s3,s4));")
+    fixed_missing <- fix.tree(no_lengths)
+
+    expect_true(inherits(fixed_missing, "phylo"))
+    expect_length(fixed_missing$edge.length, nrow(fixed_missing$edge))
+    expect_true(all(is.finite(fixed_missing$edge.length)))
+    expect_true(all(fixed_missing$edge.length > 0))
+
+    bad_lengths <- ape::read.tree(text="((s1:1,s2:1):1,s3:1);")
+    bad_lengths$edge.length <- c(Inf, 0, -1, NA)
+    fixed_bad <- fix.tree(bad_lengths)
+
+    expect_true(all(is.finite(fixed_bad$edge.length)))
+    expect_true(all(fixed_bad$edge.length > 0))
+})
+
+test_that("fix.tree leaves non-tree inputs unchanged", {
+    expect_null(fix.tree(NULL))
+    expect_equal(fix.tree("not a tree"), "not a tree")
+})


### PR DESCRIPTION
---
title: "patch-5 Change Report Relative to dev"
author: "Codex"
date: "2026-06-14"
output:
  html_document:
    toc: true
    toc_depth: 3
---

```{r setup, include=FALSE}
knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE)
```

## Scope

This report summarizes the commits present on `patch-5` that are not present on
`dev`.

Comparison used:

```sh
git log --reverse --oneline dev..patch-5
git diff --stat dev..patch-5
```

The branch contains 27 commits beyond `dev`. The changes are primarily stability
hardening, clearer input validation, bug fixes for edge cases, compatibility
updates for current R package behavior, and regression tests for statistical
behavior.

## High-Level Impact

The branch makes phylogenize fail earlier and with clearer messages when input
files, metadata, phenotype files, databases, trees, 16S alignment outputs, or FDR
inputs are malformed. It also adds regression coverage for numeric phenotype
calculations, significance calls, association testing, report rendering, database
loading, data installation, and core result shape.

The broad ramification is lower risk of silent misanalysis. Many previous failure
modes could either produce confusing downstream errors or allow malformed inputs
to affect statistics. These changes prefer explicit validation and stable,
tested behavior.

## Files Changed
```{r files_changed}
files <- c(
  "package/phylogenize/R/calc-phenotypes.R",
  "package/phylogenize/R/dummy.R",
  "package/phylogenize/R/fisher-enrich.R",
  "package/phylogenize/R/invoke.R",
  "package/phylogenize/R/load-process.R",
  "package/phylogenize/R/options.R",
  "package/phylogenize/R/plm-functions.R",
  "package/phylogenize/R/process-16S.R",
  "package/phylogenize/R/significance.R",
  "package/phylogenize/R/trees.R",
  "package/phylogenize/tests/testthat/test-calc-phenotypes.R",
  "package/phylogenize/tests/testthat/test-db-processing.R",
  "package/phylogenize/tests/testthat/test-fileio.R",
  "package/phylogenize/tests/testthat/test-fisher-enrich.R",
  "package/phylogenize/tests/testthat/test-install-data.R",
  "package/phylogenize/tests/testthat/test-invoke.R",
  "package/phylogenize/tests/testthat/test-options-isolation.R",
  "package/phylogenize/tests/testthat/test-process-16S.R",
  "package/phylogenize/tests/testthat/test-report-functions.R",
  "package/phylogenize/tests/testthat/test-report-render.R",
  "package/phylogenize/tests/testthat/test-significance-helpers.R",
  "package/phylogenize/tests/testthat/test-statistical-calibration.R",
  "package/phylogenize/tests/testthat/test-trees.R"
)
knitr::kable(data.frame(file = files), col.names = "Changed file")
```

## Commit-by-Commit Summary

### `a2ea11b` - Harden metadata environment validation

What changed: strengthens metadata processing in
`package/phylogenize/R/load-process.R`. Categorical environment columns now reject
missing values. Continuous environment columns now reject nonnumeric values and
missing values instead of letting coercion quietly introduce `NA`s. The metadata
before/after comparison was also made NA-aware.

Ramification: this is a bug fix and stability improvement. It prevents malformed
environment metadata from silently changing phenotype calculations or failing
later with less actionable errors.

### `5110421` - Validate phylogenize database inputs

What changed: adds checks that the database index exists, contains required
columns, references existing files, and that loaded gene presence, tree,
taxonomy, and function tables have the expected shape and required columns.

Ramification: this is a bug fix for bad or incomplete installed databases.
Instead of obscure failures during association testing or reporting, users now
get direct errors identifying the missing file or column.

### `8b40664` - Validate 16S vsearch inputs and output

What changed: `run.vsearch()` now validates the vsearch executable, query FASTA,
reference FASTA, and identity cutoff. `get.vsearch.results()` now checks that the
output file exists, is non-empty, has enough columns, contains numeric percent
identity values, and uses parseable query and target identifiers.

Ramification: this is a bug fix for 16S workflows. It prevents empty or malformed
alignment output from being interpreted as valid mappings.

### `e94f7b1` - Reject duplicate and blank input identifiers

What changed: abundance matrix and metadata sanity checks now reject blank,
missing, and duplicate taxon or sample identifiers.

Ramification: this is a bug fix for ambiguous sample/taxon matching. Duplicate or
blank IDs can cause incorrect joins, dropped samples, or duplicated observations;
the code now stops before those ambiguities affect downstream statistics.

### `ff13530` - Validate provided phenotype inputs

What changed: provided phenotype files are now checked for existence, row and
column count, blank or duplicate taxon IDs, numeric phenotype values, finite
values, and required shrinkage columns when standard errors are supplied.

Ramification: this is a bug fix for externally supplied phenotypes. It prevents
bad phenotype tables from producing `NA` phenotypes, invalid shrinkage inputs, or
empty overlap with database taxa.

### `41e5304` - Validate specificity prior files

What changed: specificity prior files now support explicit path resolution,
CSV/TSV parsing, required `env` and `prior` columns, duplicate environment
checks, numeric prior validation, positive finite prior validation, retained
environment coverage, and normalization when priors do not sum to one.

Ramification: this is a bug fix for specificity calculations. It prevents invalid
or incomplete prior files from biasing environmental specificity estimates or
failing later inside the model.

### `6653cf5` - Repair invalid tree branch lengths

What changed: `fix.tree()` now handles missing branch lengths, zero lengths,
negative lengths, `NA`, and infinite lengths. It replaces invalid values with a
small positive length derived from valid branch lengths when possible.

Ramification: this is a bug fix for phylogenetic model stability. Invalid branch
lengths can break tree operations or model fitting; repaired trees are more
robust while preserving topology.

### `29180b3` - Validate FDR p-value inputs

What changed: `qvals()` now validates `fdr_method`, handles empty inputs,
preserves names, ignores missing p-values while retaining their positions, and
rejects non-finite or out-of-range p-values.

Ramification: this is a bug fix for significance calling. It prevents invalid
p-values from feeding FDR correction and keeps gene names aligned with adjusted
values.

### `c3ee9dd` - Validate report template availability

What changed: report rendering now verifies the requested R Markdown template is
available from the installed package and that it can be copied into the output
directory.

Ramification: this is a bug fix for report generation. Missing templates or copy
failures now produce explicit errors before rendering starts.

### `658b477` - Preserve gene names in q-value helpers

What changed: significance helper code now preserves names while extracting
p-values and effect sizes from result matrices.

Ramification: this is a bug fix. Losing names during q-value calculation can
misalign significant gene identifiers with their statistics.

### `0eb7304` - Expand stability regression coverage

What changed: adds regression tests around phenotype validation, database
processing, 16S validation, and significance helper behavior.

Ramification: this adds test coverage. It reduces the chance that future changes
reopen the validation and name-preservation bugs fixed earlier in the branch.

### `1cf6690` - Avoid deprecated tidyr unnest call

What changed: replaces legacy `tidyr::unnest()` calls with explicit
`cols = ...` usage.

Ramification: this is a compatibility and stability fix. It avoids warnings or
breakage as tidyr evolves and keeps the code behavior explicit.

### `8d897da` - Quiet internal database index loading

What changed: adds `read.internal.database.index()` using base `read.csv()` for
internal database listing and validation. `set_data_internal()` and
`check_data_found()` use this helper.

Ramification: this is a stability and user-experience improvement. Startup and
data directory checks avoid noisy readr output and validate database names more
directly.

### `b0a5536` - Cover native BIOM import path

What changed: replaces test BIOM writing through the external biom command-line
tool with `biomformat::make_biom()` and `biomformat::write_biom()`. Adds coverage
for native BIOM import behavior.

Ramification: this is a stability improvement for tests and fixture generation.
It removes dependence on external biom CLI availability for this test path.

### `c8c9075` - Update legacy enrichment unnest calls

What changed: updates enrichment code in `fisher-enrich.R` to use explicit
`tidyr::unnest(cols = ...)` calls.

Ramification: this is a compatibility fix. It prevents deprecation-related
warnings and future tidyr incompatibilities in enrichment workflows.

### `b2880f2` - Suppress expected abundance parse warnings

What changed: tabular abundance import now muffles readr/vroom parse warnings
only for the expected parse issue path, while retaining explicit downstream
validation of bad columns.

Ramification: this is a stability and test-noise fix. Expected parser warnings no
longer obscure real test failures, while invalid abundance values are still
reported by phylogenize's own checks.

### `23543ac` - Harden data installation helper

What changed: `install_data()` now validates path input, file existence, extdata
directory existence, write permissions, overwrite behavior, supported file
extensions, copy success, unzip success, and returns installed paths invisibly.

Ramification: this is a bug fix for data installation. Failed installs now stop
with a useful message instead of silently doing nothing or partially installing
data.

### `c12537d` - Add null statistical calibration test

What changed: adds statistical calibration tests for null behavior.

Ramification: this adds statistical regression coverage. It helps detect changes
that would inflate false positives under null-like data.

### `abdc84e` - Add FDR method snapshot tests

What changed: adds tests that snapshot expected FDR behavior for supported
methods.

Ramification: this adds statistical stability coverage. It helps ensure future
changes do not alter q-value behavior unexpectedly.

### `794dbc9` - Preserve gene names in sign helpers

What changed: `make.signs()` now converts effect sizes to numeric values while
explicitly assigning column names back to the resulting vector.

Ramification: this is a bug fix. It preserves gene identifiers after sign
extraction, which is necessary for correct downstream enrichment and significance
matching.

### `b794d6b` - Add ordering invariance statistic test

What changed: adds tests that confirm statistics are invariant to input ordering
where ordering should not matter.

Ramification: this adds regression coverage for a subtle class of bugs. Future
changes that accidentally make results depend on row or column order should be
caught.

### `cc11d65` - Add known-signal association regression test

What changed: adds a test case with a known association signal.

Ramification: this adds statistical regression coverage. It checks that the
association pipeline can still recover an expected signal after code changes.

### `89d2257` - Add association method comparison test

What changed: adds tests comparing association methods on controlled inputs.

Ramification: this adds statistical coverage across method choices. It reduces
the risk that one association backend changes behavior unnoticed.

### `2129f9b` - Add core object stability test

What changed: adds tests for the shape and key contents of the object returned by
`phylogenize_core()`.

Ramification: this adds API stability coverage. Downstream users and report
generation depend on this object shape, so the test catches breaking structural
changes.

### `cb63dab` - Add phenotype numeric regression tests

What changed: adds fixed-value tests for prevalence, specificity, and CLR
correlation phenotype calculations.

Ramification: this adds statistical regression coverage. It helps ensure future
refactors do not silently change phenotype values.

### `5baa4a8` - Add golden core association regression test
What changed: adds a deterministic golden test for core association results.

Ramification: this adds end-to-end statistical coverage. It gives the branch a
guardrail against unintentional changes to core association output.

### `2a49633` - Clean up expected test warnings

What changed: expected warnings in tests are now explicitly captured or
suppressed where the warning is part of the scenario being tested. The commit
also restores `filter.incomplete.metadata.samples()` for the PLM test path.

Ramification: this is both a test stability fix and a bug fix. The test suite now
passes with zero testthat warnings, and the missing helper no longer causes the
PLM tests to fail in a full-suite run.

## Testing Status

The branch was retested with:

```sh
conda run -n phylogenize2 Rscript -e 'pkgload::load_all("package/phylogenize", quiet=TRUE); testthat::test_dir("package/phylogenize/tests/testthat")'
```

Most recent observed result:

```text
[ FAIL 0 | WARN 0 | SKIP 1 | PASS 301 ]
```

The single skip is the expected 16S mapping test that requires external FASTA and
vsearch/appspam data not distributed with the tests.

## Review Notes

The branch is mostly defensive hardening and regression coverage. The highest
impact behavioral changes are:

- invalid metadata, abundance, phenotype, prior, database, tree, and vsearch
  inputs now stop earlier;
- significance helpers preserve gene names more reliably;
- FDR correction rejects invalid p-values rather than adjusting them;
- report and data installation failures produce direct errors;
- tests now cover several statistical invariants and known numeric outputs.

These changes should make failures more explicit and reduce silent statistical
drift in future development.
