### PR TITLE
Bug and 16S Stability Patch

### DIFF
--- a/package/phylogenize/DESCRIPTION
+++ b/package/phylogenize/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phylogenize
 Title: Associate Microbial Prevalence, Specificity, and Abundance with Gene Presence
-Version: 2.0.3
+Version: 2.0.4
 Authors@R: 
     c(person(given = "Patrick",
            family = "Bradley",

--- a/package/phylogenize/DESCRIPTION
+++ b/package/phylogenize/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phylogenize
 Title: Associate Microbial Prevalence, Specificity, and Abundance with Gene Presence
-Version: 2.0.1
+Version: 2.0.3
 Authors@R: 
     c(person(given = "Patrick",
            family = "Bradley",

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -805,7 +805,7 @@ change.tree.tax.level <- function(tree, taxon, tax, ..., .opts=NULL) {
 #' @return none
 #' @export
 process.16s <- function(abd.meta, ..., .opts=NULL) {
-    opts <- pz.resolve.options(..., .opts=.opts)
+    opts <- resolve.16s.paths(..., .opts=.opts)
     if (!(all(is.dna(rownames(abd.meta$mtx))))) {
         pz.error(paste0("expected rows to be DNA sequences but found illegal ",
                         "characters"),
@@ -828,6 +828,25 @@ process.16s <- function(abd.meta, ..., .opts=NULL) {
         ), .opts=opts)
     }
     summed.uniq <- sum.nonunique.vsearch(results_16s, abd.meta$mtx, ..., .opts=opts)
+    stats_16s <- attr(summed.uniq, "phylogenize_16s_stats")
+    if (!is.null(stats_16s)) {
+        pz.message(paste0(
+            "  ..........16S mapping retained ",
+            stats_16s$retained_asvs,
+            " of ",
+            stats_16s$total_asvs,
+            " ASV(s) as ",
+            stats_16s$retained_species,
+            " species row(s)"
+        ), .opts=opts)
+        pz.message(paste0(
+            "  ..........16S mapping retained ",
+            signif(stats_16s$retained_abundance, 4),
+            " of ",
+            signif(stats_16s$total_abundance, 4),
+            " total abundance"
+        ), .opts=opts)
+    }
     if (nrow(summed.uniq) == 0) {
         pz.error(paste0(
             "No 16S ASVs were retained after mapping; check reference ",
@@ -842,6 +861,13 @@ process.16s <- function(abd.meta, ..., .opts=NULL) {
             "check ASV assignments and abundance values"
         ), .opts=opts)
     }
+    pz.message(paste0(
+        "  ..........16S mapping retained ",
+        length(keep_samples),
+        " of ",
+        ncol(summed.uniq),
+        " sample(s) with nonzero mapped abundance"
+    ), .opts=opts)
     abd.meta$mtx <- summed.uniq[, keep_samples, drop=FALSE]
     # don't convert to relative abundance...
     # abd.meta$mtx <- apply(summed.uniq[, which(csu > 0), drop=FALSE],

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -829,6 +829,10 @@ process.16s <- function(abd.meta, ..., .opts=NULL) {
     }
     summed.uniq <- sum.nonunique.vsearch(results_16s, abd.meta$mtx, ..., .opts=opts)
     stats_16s <- attr(summed.uniq, "phylogenize_16s_stats")
+    audit_16s <- attr(summed.uniq, "phylogenize_16s_audit")
+    if (!is.null(audit_16s)) {
+        write.16s.audit(audit_16s, .opts=opts)
+    }
     if (!is.null(stats_16s)) {
         pz.message(paste0(
             "  ..........16S mapping retained ",

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -822,8 +822,10 @@ process.16s <- function(abd.meta, ..., .opts=NULL) {
     } else if (opts('which_16s_method')=="jplace") {
         results_16s <- get.appspam.results(..., .opts=opts)
     } else {
-        pz.error("which_16s_method must be vsearch, appspam, or jplace",
-                 .opts=opts)
+        pz.error(paste0(
+            "type_16S=TRUE requires which_16s_method to be explicitly set ",
+            "to vsearch, appspam, or jplace"
+        ), .opts=opts)
     }
     summed.uniq <- sum.nonunique.vsearch(results_16s, abd.meta$mtx, ..., .opts=opts)
     csu <- colSums(summed.uniq)

--- a/package/phylogenize/R/load-process.R
+++ b/package/phylogenize/R/load-process.R
@@ -828,8 +828,21 @@ process.16s <- function(abd.meta, ..., .opts=NULL) {
         ), .opts=opts)
     }
     summed.uniq <- sum.nonunique.vsearch(results_16s, abd.meta$mtx, ..., .opts=opts)
+    if (nrow(summed.uniq) == 0) {
+        pz.error(paste0(
+            "No 16S ASVs were retained after mapping; check reference ",
+            "coverage, min_frac_16s, and ambiguous assignments"
+        ), .opts=opts)
+    }
     csu <- colSums(summed.uniq)
-    abd.meta$mtx <- summed.uniq[, which(csu > 0), drop=FALSE]
+    keep_samples <- which(csu > 0)
+    if (length(keep_samples) == 0) {
+        pz.error(paste0(
+            "No samples retained nonzero abundance after 16S mapping; ",
+            "check ASV assignments and abundance values"
+        ), .opts=opts)
+    }
+    abd.meta$mtx <- summed.uniq[, keep_samples, drop=FALSE]
     # don't convert to relative abundance...
     # abd.meta$mtx <- apply(summed.uniq[, which(csu > 0), drop=FALSE],
     #                       2,

--- a/package/phylogenize/R/options.R
+++ b/package/phylogenize/R/options.R
@@ -62,8 +62,8 @@ default_params <- list(
     vsearch_16sfile = "16s_gtdb.frn",
     vsearch_cutoff = 0.985,
     vsearch_dir = "",
-    named_asv_file = "input_seqs.txt",
-    vsearch_outfile = "output_assignments.txt"
+    named_asv_file = "",
+    vsearch_outfile = ""
 )
 
 
@@ -96,9 +96,9 @@ PZ_OPTIONS <- settings::options_manager(.list=default_params)
 #'   \item{which_16s_method}{String. Required when \code{type_16S=TRUE}. Can be "vsearch" (best-hit alignment), "appspam" (perform phylogenetic placement), or "jplace" (bring-your-own .jplace file). Default: ""}
 #'   \item{vsearch_16sfile}{String. Path to the 16S FASTA database that maps back to MIDAS species. Default: "16s_gtdb.frn"}
 #'   \item{vsearch_dir}{String. Path where the binary of the aligner is found. Default: "/usr/local/bin/"}
-#'   \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: "input_seqs.txt"}
-#'   \item{vsearch_outfile}{String. File name where the aligner writes output which is then read back into \emph{phylogenize}. Default: "output_assignments.txt"}
-#'   \item{jplace_file}{String. Path to write .jplace file (if which_16s_method is "appspam") or to read user-provided .jplace file (if which_16s_method is "jplace".) \emph{phylogenize}. Default: ""}
+#'   \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: \code{file.path(out_dir, "phylogenize-16s-asvs.fna")}}
+#'   \item{vsearch_outfile}{String. File name where the aligner writes output which is then read back into \emph{phylogenize}. Default: \code{file.path(out_dir, "phylogenize-16s-vsearch.tsv")}}
+#'   \item{jplace_file}{String. Path to write .jplace file (if which_16s_method is "appspam") or to read user-provided .jplace file (if which_16s_method is "jplace".) Default for appspam: \code{file.path(out_dir, "phylogenize-16s.jplace")}}
 #'   \item{aln_path_16s}{String. Path to the multiple alignment of 16S sequences used for phylogenetic placement. Default: ""}
 #'   \item{tree_path_16s}{String. Path to the tree of 16S sequences used for phylogenetic placement. \emph{phylogenize}. Default: ""}
 #'   \item{min_frac_16s}{Numeric. Should be between 0.5 and 1. Only keep ASVs where at least this fraction of assignments are to the same species. Allows some tolerance for mislabeled or phylogenetically-inconsistent 16S sequences in the database. Default: 0.8}

--- a/package/phylogenize/R/options.R
+++ b/package/phylogenize/R/options.R
@@ -63,7 +63,8 @@ default_params <- list(
     vsearch_cutoff = 0.985,
     vsearch_dir = "",
     named_asv_file = "",
-    vsearch_outfile = ""
+    vsearch_outfile = "",
+    audit_16s_file = ""
 )
 
 
@@ -98,6 +99,7 @@ PZ_OPTIONS <- settings::options_manager(.list=default_params)
 #'   \item{vsearch_dir}{String. Path where the binary of the aligner is found. Default: "/usr/local/bin/"}
 #'   \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: \code{file.path(out_dir, "phylogenize-16s-asvs.fna")}}
 #'   \item{vsearch_outfile}{String. File name where the aligner writes output which is then read back into \emph{phylogenize}. Default: \code{file.path(out_dir, "phylogenize-16s-vsearch.tsv")}}
+#'   \item{audit_16s_file}{String. File name where the 16S ASV-to-species assignment audit table is written. Default: \code{file.path(out_dir, "phylogenize-16s-assignments.tsv")}}
 #'   \item{jplace_file}{String. Path to write .jplace file (if which_16s_method is "appspam") or to read user-provided .jplace file (if which_16s_method is "jplace".) Default for appspam: \code{file.path(out_dir, "phylogenize-16s.jplace")}}
 #'   \item{aln_path_16s}{String. Path to the multiple alignment of 16S sequences used for phylogenetic placement. Default: ""}
 #'   \item{tree_path_16s}{String. Path to the tree of 16S sequences used for phylogenetic placement. \emph{phylogenize}. Default: ""}

--- a/package/phylogenize/R/options.R
+++ b/package/phylogenize/R/options.R
@@ -58,7 +58,7 @@ default_params <- list(
     jplace_file="",
     min_frac_16s=0.8,		       
     appspam_path="/usr/local/bin/appspam",
-    which_16s_method="appspam",
+    which_16s_method="",
     vsearch_16sfile = "16s_gtdb.frn",
     vsearch_cutoff = 0.985,
     vsearch_dir = "",
@@ -93,7 +93,7 @@ PZ_OPTIONS <- settings::options_manager(.list=default_params)
 #'   \item{output_file}{String. Name of output file: "results.html"}
 #'   \item{prior_file}{String. File name of optional pre-computed prior. Default: ""}
 #'   \item{separate_metadata}{Boolean. For BIOM data, is there a separate tabular metadata table? Default: FALSE}
-#'   \item{which_16s_method}{String. Can be "vsearch" (best-hit alignment), "appspam" (perform phylogenetic placement), or "jplace" (bring-your-own .jplace file). Default: "appspam"}
+#'   \item{which_16s_method}{String. Required when \code{type_16S=TRUE}. Can be "vsearch" (best-hit alignment), "appspam" (perform phylogenetic placement), or "jplace" (bring-your-own .jplace file). Default: ""}
 #'   \item{vsearch_16sfile}{String. Path to the 16S FASTA database that maps back to MIDAS species. Default: "16s_gtdb.frn"}
 #'   \item{vsearch_dir}{String. Path where the binary of the aligner is found. Default: "/usr/local/bin/"}
 #'   \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: "input_seqs.txt"}

--- a/package/phylogenize/R/plm-functions.R
+++ b/package/phylogenize/R/plm-functions.R
@@ -1615,6 +1615,7 @@ pz.warning <- function(msgtext, ...) {
 threshold.pos.sigs <- function(pz.db, phy.with.sigs, pos.sig, ..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
     Min <- opts('minimum')
+    GMF <- opts('gene_min_frac')
     mapply(pz.db$trees[phy.with.sigs],
            pos.sig[phy.with.sigs],
            pz.db$gene.presence[phy.with.sigs],
@@ -1623,8 +1624,9 @@ threshold.pos.sigs <- function(pz.db, phy.with.sigs, pos.sig, ..., .opts=NULL) {
                if (length(i) == 0) { return(character(0)) }
                if (length(x) == 0) { return(character(0)) }
                y2 <- y[x, i, drop=FALSE]
-               r1 <- rowSums(y2)
-               r2 <- rowSums(1 - y2)
+               ybin <- y2 > GMF
+               r1 <- Matrix::rowSums(ybin)
+               r2 <- Matrix::rowSums(!ybin)
                names(which((r2 >= Min) & (r1 >= Min)))
            },
            SIMPLIFY=FALSE)

--- a/package/phylogenize/R/process-16S.R
+++ b/package/phylogenize/R/process-16S.R
@@ -1,6 +1,32 @@
 
 #--- Process 16S data---#
 
+resolve.16s.paths <- function(..., .opts=NULL) {
+    opts <- pz.resolve.options(..., .opts=.opts)
+    out_dir <- opts('out_dir')
+    if (is.null(out_dir) || is.na(out_dir) || out_dir == "") {
+        out_dir <- "."
+    }
+    path_or_default <- function(value, filename) {
+        if (is.null(value) || is.na(value) || value == "") {
+            file.path(out_dir, filename)
+        } else {
+            value
+        }
+    }
+    updates <- list(
+        named_asv_file=path_or_default(opts('named_asv_file'),
+                                       "phylogenize-16s-asvs.fna"),
+        vsearch_outfile=path_or_default(opts('vsearch_outfile'),
+                                        "phylogenize-16s-vsearch.tsv")
+    )
+    if (opts('which_16s_method') == "appspam") {
+        updates$jplace_file <- path_or_default(opts('jplace_file'),
+                                               "phylogenize-16s.jplace")
+    }
+    do.call(pz.resolve.options, c(list(.opts=opts), updates))
+}
+
 #' Prepare input file for alignment
 #'
 #' \code{prepare.vsearch.input} outputs a FASTA file of the sequences in the
@@ -16,7 +42,7 @@
 #'   amplicon sequence variant DNA sequences.
 #' @export
 prepare.vsearch.input <- function(mtx, ..., .opts=NULL) {
-    opts <- pz.resolve.options(..., .opts=.opts)
+    opts <- resolve.16s.paths(..., .opts=.opts)
     check.dna <- is.dna(rownames(mtx))
     if (!(all(check.dna))) {
         pz.error(paste0(
@@ -28,6 +54,7 @@ prepare.vsearch.input <- function(mtx, ..., .opts=NULL) {
     }
     asvnames = paste0("Row", (1:nrow(mtx)))
     asvs = rownames(mtx)
+    ensure_parent_dir(opts('named_asv_file'), .opts=opts)
     seqinr::write.fasta(as.list(asvs),
                         asvnames,
                         file.out=opts('named_asv_file'),
@@ -83,7 +110,7 @@ run.external.tool <- function(command,
 #' @return Returns TRUE unless an error is thrown.
 #' @export run.vsearch
 run.vsearch <- function(..., .opts=NULL) {
-    opts <- pz.resolve.options(..., .opts=.opts)
+    opts <- resolve.16s.paths(..., .opts=.opts)
     vsearch_path <- opts('vsearch_dir')
     if (dir.exists(vsearch_path)) {
         vsearch_path <- file.path(vsearch_path, "vsearch")
@@ -112,6 +139,7 @@ run.vsearch <- function(..., .opts=NULL) {
                  .opts=opts)
     }
     binary <- basename(vsearch_path)
+    ensure_parent_dir(opts('vsearch_outfile'), .opts=opts)
     vsearch_args <- c("--db",
 			     db_file,
 			     "--usearch_global",
@@ -149,7 +177,7 @@ run.vsearch <- function(..., .opts=NULL) {
 #'     data frame of the assignments as they came out of vsearch.
 #' @export
 get.vsearch.results <- function(..., .opts=NULL) {
-    opts <- pz.resolve.options(..., .opts=.opts)
+    opts <- resolve.16s.paths(..., .opts=.opts)
     vf <- opts('vsearch_outfile')
     if (!(file.exists(vf))) {
         pz.error(paste0("vsearch output file not found: ", vf), .opts=opts)
@@ -229,6 +257,8 @@ get.vsearch.results <- function(..., .opts=NULL) {
 sum.nonunique.vsearch <- function(vsearch, mtx, ..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
     min_frac <- opts("min_frac_16s")
+    total_asvs <- nrow(mtx)
+    mapped_asvs <- length(unique(vsearch$hits))
     vs_tbl <- tibble::tibble(hits=vsearch$hits, targets=vsearch$targets) %>% 
 	    dplyr::group_by(hits) %>%
 	    dplyr::count(targets, name="n") %>%
@@ -244,7 +274,17 @@ sum.nonunique.vsearch <- function(vsearch, mtx, ..., .opts=NULL) {
     subset.abd <- mtx[rh, , drop=FALSE]
     urt <- unique(rt)
     summed.uniq <- rowsum(as.matrix(subset.abd), group=rt, reorder=FALSE)
-    summed.uniq[urt, , drop=FALSE]
+    out <- summed.uniq[urt, , drop=FALSE]
+    attr(out, "phylogenize_16s_stats") <- list(
+        total_asvs=total_asvs,
+        mapped_asvs=mapped_asvs,
+        retained_asvs=length(unique(rh)),
+        dropped_asvs=total_asvs - length(unique(rh)),
+        retained_species=nrow(out),
+        total_abundance=sum(mtx),
+        retained_abundance=sum(out)
+    )
+    out
 }
 
 
@@ -263,7 +303,7 @@ sum.nonunique.vsearch <- function(vsearch, mtx, ..., .opts=NULL) {
 #' @return Returns TRUE unless an error is thrown.
 #' @export run.appspam
 run.appspam <- function(..., .opts=NULL) {
-    opts <- pz.resolve.options(..., .opts=.opts)
+    opts <- resolve.16s.paths(..., .opts=.opts)
     appspam_path <- opts('appspam_path')
     if (appspam_path == "" || !(file.exists(appspam_path))) {
         pz.error(paste0("AppSpam executable not found: ", appspam_path),
@@ -337,9 +377,23 @@ run.appspam <- function(..., .opts=NULL) {
 #'     data frame of the assignments as they came out of AppSpam 
 #' @export
 get.appspam.results <- function(..., .opts=NULL) {
-    opts <- pz.resolve.options(..., .opts=.opts)
+    opts <- resolve.16s.paths(..., .opts=.opts)
+    jplace_file <- opts('jplace_file')
+    if (jplace_file == "") {
+        pz.error("jplace_file must be provided for jplace input", .opts=opts)
+    }
+    if (!(file.exists(jplace_file))) {
+        pz.error(paste0("jplace file not found: ", jplace_file), .opts=opts)
+    }
+    if (file.access(jplace_file, mode=4) != 0) {
+        pz.error(paste0("jplace file is not readable: ", jplace_file),
+                 .opts=opts)
+    }
+    if (file.info(jplace_file)$size == 0) {
+        pz.error(paste0("jplace file was empty: ", jplace_file), .opts=opts)
+    }
     # map to MIDAS IDs using vsearch
-    placements <- treeio::read.jplace(opts('jplace_file'))
+    placements <- treeio::read.jplace(jplace_file)
     tr <- treeio::get.tree(placements)
     pl <- treeio::get.placements(placements)
     edge <- tibble::as_tibble(tr$edge) %>%

--- a/package/phylogenize/R/process-16S.R
+++ b/package/phylogenize/R/process-16S.R
@@ -205,7 +205,8 @@ get.vsearch.results <- function(..., .opts=NULL) {
 #' \code{sum.nonunique.vsearch} takes vsearch results and an abundance or
 #' presence/absence matrix, drops any rows that mapped to multiple MIDAS IDs
 #' (i.e. that couldn't confidently be assigned to a MIDAS species),
-#' then sums any rows that mapped to the same MIDAS ID.
+#' then sums any rows that mapped to the same MIDAS ID. An ASV is retained only
+#' if exactly one MIDAS ID reaches \code{min_frac_16s}.
 #'
 #' Some particularly relevant options are:
 #' \describe{
@@ -233,7 +234,11 @@ sum.nonunique.vsearch <- function(vsearch, mtx, ..., .opts=NULL) {
 	    dplyr::count(targets, name="n") %>%
 	    dplyr::mutate(frac = n/sum(n)) %>%
 	    dplyr::ungroup()
-    vs_tbl_f <- dplyr::filter(vs_tbl, frac >= min_frac)
+    vs_tbl_f <- vs_tbl %>%
+        dplyr::group_by(hits) %>%
+        dplyr::filter(frac >= min_frac) %>%
+        dplyr::filter(dplyr::n() == 1) %>%
+        dplyr::ungroup()
     rh <- vs_tbl_f$hits
     rt <- vs_tbl_f$targets
     subset.abd <- mtx[rh, , drop=FALSE]

--- a/package/phylogenize/R/process-16S.R
+++ b/package/phylogenize/R/process-16S.R
@@ -259,19 +259,64 @@ sum.nonunique.vsearch <- function(vsearch, mtx, ..., .opts=NULL) {
 #' @export run.appspam
 run.appspam <- function(..., .opts=NULL) {
     opts <- pz.resolve.options(..., .opts=.opts)
+    appspam_path <- opts('appspam_path')
+    if (appspam_path == "" || !(file.exists(appspam_path))) {
+        pz.error(paste0("AppSpam executable not found: ", appspam_path),
+                 .opts=opts)
+    }
+    if (file.access(appspam_path, mode=1) != 0) {
+        pz.error(paste0("AppSpam executable is not runnable: ",
+                        appspam_path),
+                 .opts=opts)
+    }
+    aln_file <- opts('aln_path_16s')
+    if (aln_file == "" || !(file.exists(aln_file))) {
+        pz.error(paste0("16S alignment file not found: ", aln_file),
+                 .opts=opts)
+    }
+    tree_file <- opts('tree_path_16s')
+    if (tree_file == "" || !(file.exists(tree_file))) {
+        pz.error(paste0("16S tree file not found: ", tree_file),
+                 .opts=opts)
+    }
+    query_file <- opts('named_asv_file')
+    if (query_file == "" || !(file.exists(query_file))) {
+        pz.error(paste0("16S query FASTA not found: ", query_file),
+                 .opts=opts)
+    }
+    jplace_file <- opts('jplace_file')
+    if (jplace_file == "") {
+        pz.error("jplace_file must be provided for AppSpam output",
+                 .opts=opts)
+    }
+    jplace_dir <- dirname(jplace_file)
+    if (!(dir.exists(jplace_dir))) {
+        pz.error(paste0("AppSpam output directory not found: ", jplace_dir),
+                 .opts=opts)
+    }
+    if (file.access(jplace_dir, mode=2) != 0) {
+        pz.error(paste0("AppSpam output directory is not writable: ",
+                        jplace_dir),
+                 .opts=opts)
+    }
+    ncl <- suppressWarnings(as.numeric(opts('ncl')))
+    if (is.na(ncl) || !is.finite(ncl) || ncl < 1 || ncl != as.integer(ncl)) {
+        pz.error("ncl must be a positive integer for AppSpam",
+                 .opts=opts)
+    }
     appspam_args <- c(
             "-s", 
-            opts('aln_path_16s'),
+            aln_file,
             "-t",
-            opts('tree_path_16s'),
+            tree_file,
             "-q",
-            opts('named_asv_file'),
+            query_file,
 	    "--threads",
-            opts('ncl'),
+            ncl,
             "-o",
-            opts('jplace_file') # in setup should check if exists
+            jplace_file
     )
-    run.external.tool(opts('appspam_path'),
+    run.external.tool(appspam_path,
                       appspam_args,
                       error_label="AppSpam",
                       .opts=opts)

--- a/package/phylogenize/R/process-16S.R
+++ b/package/phylogenize/R/process-16S.R
@@ -18,13 +18,29 @@ resolve.16s.paths <- function(..., .opts=NULL) {
         named_asv_file=path_or_default(opts('named_asv_file'),
                                        "phylogenize-16s-asvs.fna"),
         vsearch_outfile=path_or_default(opts('vsearch_outfile'),
-                                        "phylogenize-16s-vsearch.tsv")
+                                        "phylogenize-16s-vsearch.tsv"),
+        audit_16s_file=path_or_default(opts('audit_16s_file'),
+                                       "phylogenize-16s-assignments.tsv")
     )
     if (opts('which_16s_method') == "appspam") {
         updates$jplace_file <- path_or_default(opts('jplace_file'),
                                                "phylogenize-16s.jplace")
     }
     do.call(pz.resolve.options, c(list(.opts=opts), updates))
+}
+
+write.16s.audit <- function(audit, ..., .opts=NULL) {
+    opts <- resolve.16s.paths(..., .opts=.opts)
+    audit_file <- opts('audit_16s_file')
+    if (is.null(audit_file) || is.na(audit_file) || audit_file == "") {
+        return(invisible(FALSE))
+    }
+    ensure_parent_dir(audit_file, .opts=opts)
+    readr::write_tsv(audit, audit_file)
+    pz.message(paste0("  ..........16S assignment audit written to ",
+                      audit_file),
+               .opts=opts)
+    invisible(TRUE)
 }
 
 #' Prepare input file for alignment
@@ -269,6 +285,49 @@ sum.nonunique.vsearch <- function(vsearch, mtx, ..., .opts=NULL) {
         dplyr::filter(frac >= min_frac) %>%
         dplyr::filter(dplyr::n() == 1) %>%
         dplyr::ungroup()
+    retained_by_hit <- vs_tbl_f %>%
+        dplyr::transmute(hits, retained_target=targets)
+    decisions <- vs_tbl %>%
+        dplyr::group_by(hits) %>%
+        dplyr::summarise(
+            n_retained_candidates=sum(frac >= min_frac),
+            drop_reason=dplyr::case_when(
+                n_retained_candidates == 1 ~ "retained",
+                n_retained_candidates == 0 ~ "below_min_frac_16s",
+                TRUE ~ "ambiguous_assignment"
+            ),
+            .groups="drop"
+        ) %>%
+        dplyr::left_join(retained_by_hit, by="hits")
+    audit <- vs_tbl %>%
+        dplyr::left_join(decisions, by="hits") %>%
+        dplyr::transmute(
+            asv_row=hits,
+            asv_sequence=rownames(mtx)[hits],
+            candidate_target=targets,
+            assignment_count=n,
+            assignment_fraction=frac,
+            retained_target=retained_target,
+            retained=!is.na(retained_target) & targets == retained_target,
+            drop_reason=drop_reason
+        )
+    unmapped_hits <- setdiff(seq_len(total_asvs), unique(vs_tbl$hits))
+    if (length(unmapped_hits) > 0) {
+        audit <- dplyr::bind_rows(
+            audit,
+            tibble::tibble(
+                asv_row=unmapped_hits,
+                asv_sequence=rownames(mtx)[unmapped_hits],
+                candidate_target=NA_character_,
+                assignment_count=0L,
+                assignment_fraction=0,
+                retained_target=NA_character_,
+                retained=FALSE,
+                drop_reason="unmapped"
+            )
+        )
+    }
+    audit <- dplyr::arrange(audit, asv_row, candidate_target)
     rh <- vs_tbl_f$hits
     rt <- vs_tbl_f$targets
     subset.abd <- mtx[rh, , drop=FALSE]
@@ -284,6 +343,7 @@ sum.nonunique.vsearch <- function(vsearch, mtx, ..., .opts=NULL) {
         total_abundance=sum(mtx),
         retained_abundance=sum(out)
     )
+    attr(out, "phylogenize_16s_audit") <- audit
     out
 }
 

--- a/package/phylogenize/R/process-16S.R
+++ b/package/phylogenize/R/process-16S.R
@@ -456,14 +456,19 @@ get.appspam.results <- function(..., .opts=NULL) {
     placements <- treeio::read.jplace(jplace_file)
     tr <- treeio::get.tree(placements)
     pl <- treeio::get.placements(placements)
-    edge <- tibble::as_tibble(tr$edge) %>%
+    edge <- tibble::tibble(V1=tr$edge[, 1], V2=tr$edge[, 2]) %>%
         dplyr::mutate(edge_num=row_number()) %>%
-        dplyr::inner_join(., pl)
-    cl <- parallel::makeCluster(opts('ncl'))
-    on.exit(parallel::stopCluster(cl), add=TRUE)
-    tidy_tips <- parallel::parLapply(cl, edge$V1, \(.x, tr) {
+        dplyr::inner_join(., pl, by="edge_num")
+    get_tips <- function(.x, tr) {
         tr$tip.label[tidytree::offspring(tr, .x, type="tips")]
-    }, tr)
+    }
+    if (opts('ncl') == 1) {
+        tidy_tips <- lapply(edge$V1, get_tips, tr)
+    } else {
+        cl <- parallel::makeCluster(opts('ncl'))
+        on.exit(parallel::stopCluster(cl), add=TRUE)
+        tidy_tips <- parallel::parLapply(cl, edge$V1, get_tips, tr)
+    }
     #tidy_tips <- purrr::map(edge$V1, ~ {
     #    tr$tip.label[tidytree::offspring(tr, .x, type="tips")]
     #}, .progress=TRUE)

--- a/package/phylogenize/R/report-functions.R
+++ b/package/phylogenize/R/report-functions.R
@@ -413,7 +413,9 @@ single.cluster.plot <- function(gene.presence,
     if (length(sig.genes) > 1) {
         if (length(sig.genes) >= 10) {
             # cluster within three relative PD groups
-            rel_pds <- apply(sig.bin, 1, \(x) get_rel_pd(x, tree, flip_sign = TRUE))
+            rel_pds <- apply(sig.bin, 1, \(x) {
+                get_rel_pd(x, tree, flip_sign = TRUE, .opts=opts)
+            })
             #pd_groups <- cut(rank(rel_pds), 3)
             pd_groups <- cut(rel_pds, rel_pd_cut)
             names(pd_groups) <- names(rel_pds)
@@ -422,7 +424,8 @@ single.cluster.plot <- function(gene.presence,
                 if (length(these_genes) < 2) {
                     return(these_genes)
                 } else {
-                    this_clust <- hclust(dist(1 * (sig.bin[these_genes, ] >= 0.05), method='canberra'))
+                    gene_bin <- 1 * (sig.bin[these_genes, ] > opts('gene_min_frac'))
+                    this_clust <- hclust(dist(gene_bin, method='canberra'))
                     return(this_clust$labels[this_clust$order])
                 }
             })
@@ -465,8 +468,9 @@ single.cluster.plot <- function(gene.presence,
 #' Get relative PD for a gene given a tree.
 #' Relative PD here means dividing by the total branch length of the original tree.
 #' If flip_sign is TRUE, will return PD of the minor allele.
-get_rel_pd <- function(gene, tree, flip_sign=TRUE) {
-    gene_bin <- 1 * (gene >= 0.05) # hardcoded for now
+get_rel_pd <- function(gene, tree, flip_sign=TRUE, ..., .opts=NULL) {
+    opts <- pz.resolve.options(..., .opts=.opts)
+    gene_bin <- 1 * (gene > opts('gene_min_frac'))
     if (flip_sign) {
         if (mean(gene_bin) > 0.5) {
             gene_bin <- 1 - gene_bin
@@ -477,6 +481,9 @@ get_rel_pd <- function(gene, tree, flip_sign=TRUE) {
     if (length(taxa_in_common) == 0) {
         pz.warning("no tips in common with tree")
         return(NA)
+    }
+    if (length(taxa_in_common) < 2) {
+        return(0)
     }
     subt <- castor::get_subtree_with_tips(tree, taxa_in_common)$subtree
     total_pd <- sum(tree$edge.length)

--- a/package/phylogenize/man/pz.options.Rd
+++ b/package/phylogenize/man/pz.options.Rd
@@ -34,9 +34,9 @@ Descriptions of these options follow.
   \item{which_16s_method}{String. Required when \code{type_16S=TRUE}. Can be "vsearch" (best-hit alignment), "appspam" (perform phylogenetic placement), or "jplace" (bring-your-own .jplace file). Default: ""}
   \item{vsearch_16sfile}{String. Path to the 16S FASTA database that maps back to MIDAS species. Default: "16s_gtdb.frn"}
   \item{vsearch_dir}{String. Path where the binary of the aligner is found. Default: "/usr/local/bin/"}
-  \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: "input_seqs.txt"}
-  \item{vsearch_outfile}{String. File name where the aligner writes output which is then read back into \emph{phylogenize}. Default: "output_assignments.txt"}
-  \item{jplace_file}{String. Path to write .jplace file (if which_16s_method is "appspam") or to read user-provided .jplace file (if which_16s_method is "jplace".) \emph{phylogenize}. Default: ""}
+  \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: \code{file.path(out_dir, "phylogenize-16s-asvs.fna")}}
+  \item{vsearch_outfile}{String. File name where the aligner writes output which is then read back into \emph{phylogenize}. Default: \code{file.path(out_dir, "phylogenize-16s-vsearch.tsv")}}
+  \item{jplace_file}{String. Path to write .jplace file (if which_16s_method is "appspam") or to read user-provided .jplace file (if which_16s_method is "jplace".) Default for appspam: \code{file.path(out_dir, "phylogenize-16s.jplace")}}
   \item{aln_path_16s}{String. Path to the multiple alignment of 16S sequences used for phylogenetic placement. Default: ""}
   \item{tree_path_16s}{String. Path to the tree of 16S sequences used for phylogenetic placement. \emph{phylogenize}. Default: ""}
   \item{min_frac_16s}{Numeric. Should be between 0.5 and 1. Only keep ASVs where at least this fraction of assignments are to the same species. Allows some tolerance for mislabeled or phylogenetically-inconsistent 16S sequences in the database. Default: 0.8}

--- a/package/phylogenize/man/pz.options.Rd
+++ b/package/phylogenize/man/pz.options.Rd
@@ -31,7 +31,7 @@ Descriptions of these options follow.
   \item{output_file}{String. Name of output file: "results.html"}
   \item{prior_file}{String. File name of optional pre-computed prior. Default: ""}
   \item{separate_metadata}{Boolean. For BIOM data, is there a separate tabular metadata table? Default: FALSE}
-  \item{which_16s_method}{String. Can be "vsearch" (best-hit alignment), "appspam" (perform phylogenetic placement), or "jplace" (bring-your-own .jplace file). Default: "appspam"}
+  \item{which_16s_method}{String. Required when \code{type_16S=TRUE}. Can be "vsearch" (best-hit alignment), "appspam" (perform phylogenetic placement), or "jplace" (bring-your-own .jplace file). Default: ""}
   \item{vsearch_16sfile}{String. Path to the 16S FASTA database that maps back to MIDAS species. Default: "16s_gtdb.frn"}
   \item{vsearch_dir}{String. Path where the binary of the aligner is found. Default: "/usr/local/bin/"}
   \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: "input_seqs.txt"}

--- a/package/phylogenize/man/pz.options.Rd
+++ b/package/phylogenize/man/pz.options.Rd
@@ -36,6 +36,7 @@ Descriptions of these options follow.
   \item{vsearch_dir}{String. Path where the binary of the aligner is found. Default: "/usr/local/bin/"}
   \item{named_asv_file}{String. Path where sequences will be written to disk and then read into the aligner/AppSpam. Default: \code{file.path(out_dir, "phylogenize-16s-asvs.fna")}}
   \item{vsearch_outfile}{String. File name where the aligner writes output which is then read back into \emph{phylogenize}. Default: \code{file.path(out_dir, "phylogenize-16s-vsearch.tsv")}}
+  \item{audit_16s_file}{String. File name where the 16S ASV-to-species assignment audit table is written. Default: \code{file.path(out_dir, "phylogenize-16s-assignments.tsv")}}
   \item{jplace_file}{String. Path to write .jplace file (if which_16s_method is "appspam") or to read user-provided .jplace file (if which_16s_method is "jplace".) Default for appspam: \code{file.path(out_dir, "phylogenize-16s.jplace")}}
   \item{aln_path_16s}{String. Path to the multiple alignment of 16S sequences used for phylogenetic placement. Default: ""}
   \item{tree_path_16s}{String. Path to the tree of 16S sequences used for phylogenetic placement. \emph{phylogenize}. Default: ""}

--- a/package/phylogenize/tests/testthat/test-fileio.R
+++ b/package/phylogenize/tests/testthat/test-fileio.R
@@ -414,6 +414,7 @@ test_that("tabular 16S import maps ASVs to species with vsearch", {
     query_file <- file.path(tmp, "input.fna")
     db_file <- file.path(tmp, "db.fna")
     hits_file <- file.path(tmp, "hits.tsv")
+    audit_file <- file.path(tmp, "audit.tsv")
     fake_vsearch <- file.path(tmp, "vsearch")
 
     writeLines(c(
@@ -467,12 +468,19 @@ test_that("tabular 16S import maps ASVs to species with vsearch", {
         vsearch_16sfile=basename(db_file),
         named_asv_file=query_file,
         vsearch_outfile=hits_file,
+        audit_16s_file=audit_file,
         min_frac_16s=1,
         error_to_file=FALSE
     )
 
     expect_true(file.exists(query_file))
     expect_true(file.exists(hits_file))
+    expect_true(file.exists(audit_file))
+    audit <- readr::read_tsv(audit_file, show_col_types=FALSE)
+    expect_equal(
+        audit$drop_reason[audit$asv_sequence == "GGGGAAAA"],
+        "unmapped"
+    )
     expect_equal(rownames(abd.meta$mtx), c("species_a", "species_b"))
     expect_equal(colnames(abd.meta$mtx), paste0("s", 1:4))
     expect_equal(as.numeric(abd.meta$mtx["species_a", ]), c(1, 0, 2, 3))

--- a/package/phylogenize/tests/testthat/test-fileio.R
+++ b/package/phylogenize/tests/testthat/test-fileio.R
@@ -403,6 +403,80 @@ test_that("BIOM import reads native BIOM with separate metadata", {
     expect_true(is.factor(observed$metadata$env))
 })
 
-test_that("16S mapping test documents optional external reference data", {
-    skip("16S mapping requires external FASTA and vsearch/appspam data not distributed with tests.")
+test_that("tabular 16S import maps ASVs to species with vsearch", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("tabular-16s-")
+    dir.create(tmp)
+    abundance_file <- file.path(tmp, "abundance.tsv")
+    metadata_file <- file.path(tmp, "metadata.tsv")
+    query_file <- file.path(tmp, "input.fna")
+    db_file <- file.path(tmp, "db.fna")
+    hits_file <- file.path(tmp, "hits.tsv")
+    fake_vsearch <- file.path(tmp, "vsearch")
+
+    writeLines(c(
+        "taxon\ts1\ts2\ts3\ts4",
+        "ACGTACGT\t1\t0\t2\t3",
+        "TTTTCCCC\t0\t4\t1\t5",
+        "GGGGAAAA\t9\t9\t9\t9"
+    ), abundance_file)
+    writeLines(c(
+        "sample\tdataset\tenv",
+        "s1\td1\tA",
+        "s2\td1\tA",
+        "s3\td1\tB",
+        "s4\td1\tB"
+    ), metadata_file)
+    writeLines(c(
+        ">ref;;genus;;species_a",
+        "ACGTACGT",
+        ">ref;;genus;;species_b",
+        "TTTTCCCC"
+    ), db_file)
+    writeLines(c(
+        "#!/bin/sh",
+        "out=''",
+        "while [ \"$#\" -gt 0 ]; do",
+        "    if [ \"$1\" = \"--blast6out\" ]; then",
+        "        shift",
+        "        out=\"$1\"",
+        "    fi",
+        "    shift",
+        "done",
+        "printf 'Row1\\tref;;genus;;species_a\\t99\\nRow2\\tref;;genus;;species_b\\t99\\n' > \"$out\"",
+        "exit 0"
+    ), fake_vsearch)
+    Sys.chmod(fake_vsearch, mode="0755")
+
+    abd.meta <- read.abd.metadata(
+        input_format="tabular",
+        abundance_file=abundance_file,
+        metadata_file=metadata_file,
+        sample_column="sample",
+        dset_column="dataset",
+        env_column="env",
+        which_envir="A",
+        which_phenotype="abundance",
+        categorical=TRUE,
+        type_16S=TRUE,
+        which_16s_method="vsearch",
+        vsearch_dir=fake_vsearch,
+        data_dir=tmp,
+        vsearch_16sfile=basename(db_file),
+        named_asv_file=query_file,
+        vsearch_outfile=hits_file,
+        min_frac_16s=1,
+        error_to_file=FALSE
+    )
+
+    expect_true(file.exists(query_file))
+    expect_true(file.exists(hits_file))
+    expect_equal(rownames(abd.meta$mtx), c("species_a", "species_b"))
+    expect_equal(colnames(abd.meta$mtx), paste0("s", 1:4))
+    expect_equal(as.numeric(abd.meta$mtx["species_a", ]), c(1, 0, 2, 3))
+    expect_equal(as.numeric(abd.meta$mtx["species_b", ]), c(0, 4, 1, 5))
+    expect_false("GGGGAAAA" %in% rownames(abd.meta$mtx))
+    expect_equal(as.character(abd.meta$metadata$sample), paste0("s", 1:4))
 })

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -271,6 +271,26 @@ test_that("16S helpers can use resolved options without global mutation", {
     expect_equal(pz.options("min_frac_16s"), 1)
 })
 
+test_that("process.16s requires an explicit 16S mapping method", {
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 0, 0, 1),
+            nrow=2,
+            dimnames=list(c("ACGTACGT", "TTTTCCCC"), c("sample1", "sample2"))
+        ),
+        metadata=data.frame(sample=c("sample1", "sample2"))
+    )
+
+    expect_error(
+        process.16s(
+            abd.meta,
+            which_16s_method="",
+            error_to_file=FALSE
+        ),
+        "type_16S=TRUE requires which_16s_method to be explicitly set"
+    )
+})
+
 test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
     opts <- pz.resolve.options(
         min_frac_16s=0.5,

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -489,6 +489,66 @@ test_that("get.appspam.results validates jplace input before parsing", {
     )
 })
 
+test_that("process.16s maps ASVs from a jplace placement", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("jplace-workflow-")
+    dir.create(tmp)
+    jplace_file <- file.path(tmp, "placements.jplace")
+    audit_file <- file.path(tmp, "audit.tsv")
+    writeLines("{}", jplace_file)
+
+    tr <- ape::read.tree(text=paste0(
+        "((gene1____genus____species_a:1,",
+        "gene2____genus____species_a:1):1,",
+        "(gene3____genus____species_b:1,",
+        "gene4____genus____species_b:1):1);"
+    ))
+    pl <- tibble::tibble(
+        edge_num=c(2L, 5L),
+        name=c("Row1", "Row2")
+    )
+    testthat::local_mocked_bindings(
+        read.jplace=function(file) {
+            expect_equal(file, jplace_file)
+            list()
+        },
+        get.tree=function(placements) tr,
+        get.placements=function(placements) pl,
+        .package="treeio"
+    )
+
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 0, 2, 3,
+              0, 4, 1, 5),
+            nrow=2,
+            byrow=TRUE,
+            dimnames=list(c("ACGTACGT", "TTTTCCCC"), paste0("sample", 1:4))
+        ),
+        metadata=data.frame(sample=paste0("sample", 1:4))
+    )
+
+    processed <- process.16s(
+        abd.meta,
+        which_16s_method="jplace",
+        jplace_file=jplace_file,
+        audit_16s_file=audit_file,
+        min_frac_16s=1,
+        ncl=1,
+        error_to_file=FALSE
+    )
+
+    expect_equal(rownames(processed$mtx), c("species_a", "species_b"))
+    expect_equal(as.numeric(processed$mtx["species_a", ]), c(1, 0, 2, 3))
+    expect_equal(as.numeric(processed$mtx["species_b", ]), c(0, 4, 1, 5))
+    expect_true(file.exists(audit_file))
+    audit <- readr::read_tsv(audit_file, show_col_types=FALSE)
+    expect_true(all(audit$retained))
+    expect_equal(unique(audit$drop_reason), "retained")
+})
+
 test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
     opts <- pz.resolve.options(
         min_frac_16s=0.5,

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -317,6 +317,22 @@ test_that("process.16s derives default intermediate paths under out_dir", {
 
     expect_true(file.exists(file.path(out_dir, "phylogenize-16s-asvs.fna")))
     expect_true(file.exists(file.path(out_dir, "phylogenize-16s-vsearch.tsv")))
+    expect_true(file.exists(file.path(out_dir,
+                                      "phylogenize-16s-assignments.tsv")))
+    audit <- readr::read_tsv(
+        file.path(out_dir, "phylogenize-16s-assignments.tsv"),
+        show_col_types=FALSE
+    )
+    expect_equal(
+        names(audit),
+        c("asv_row", "asv_sequence", "candidate_target",
+          "assignment_count", "assignment_fraction", "retained_target",
+          "retained", "drop_reason")
+    )
+    expect_equal(audit$asv_sequence, "ACGTACGT")
+    expect_equal(audit$candidate_target, "species_a")
+    expect_true(audit$retained)
+    expect_equal(audit$drop_reason, "retained")
     expect_equal(rownames(processed$mtx), "species_a")
 })
 
@@ -381,6 +397,7 @@ test_that("process.16s errors clearly when no ASVs are retained", {
             vsearch_16sfile=basename(db_file),
             named_asv_file=query_file,
             vsearch_outfile=hits_file,
+            audit_16s_file=file.path(tmp, "audit.tsv"),
             min_frac_16s=0.5,
             error_to_file=FALSE
         ),
@@ -429,6 +446,7 @@ test_that("process.16s errors clearly when mapped samples are all zero", {
             vsearch_16sfile=basename(db_file),
             named_asv_file=query_file,
             vsearch_outfile=hits_file,
+            audit_16s_file=file.path(tmp, "audit.tsv"),
             min_frac_16s=1,
             error_to_file=FALSE
         ),
@@ -496,8 +514,10 @@ test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
 
     summed <- sum.nonunique.vsearch(vsearch, mtx, .opts=opts)
     stats <- attr(summed, "phylogenize_16s_stats")
+    audit <- attr(summed, "phylogenize_16s_audit")
     summed_mtx <- as.matrix(summed)
     attr(summed_mtx, "phylogenize_16s_stats") <- NULL
+    attr(summed_mtx, "phylogenize_16s_audit") <- NULL
 
     expect_equal(rownames(summed), c("target_b", "target_a"))
     expect_equal(
@@ -515,6 +535,16 @@ test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
     expect_equal(stats$retained_species, 2)
     expect_equal(stats$total_abundance, 78)
     expect_equal(stats$retained_abundance, 54)
+    expect_equal(nrow(audit), 5)
+    expect_equal(
+        audit$drop_reason[match(3, audit$asv_row)],
+        "ambiguous_assignment"
+    )
+    expect_true(all(!audit$retained[audit$asv_row == 3]))
+    expect_equal(
+        audit$retained_target[audit$asv_row == 4],
+        "target_a"
+    )
 })
 
 test_that("run.vsearch validates executable and input files", {

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -271,6 +271,55 @@ test_that("16S helpers can use resolved options without global mutation", {
     expect_equal(pz.options("min_frac_16s"), 1)
 })
 
+test_that("process.16s derives default intermediate paths under out_dir", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("vsearch-default-paths-")
+    out_dir <- file.path(tmp, "out")
+    dir.create(tmp)
+    fake_vsearch <- file.path(tmp, "vsearch")
+    db_file <- file.path(tmp, "db.fna")
+    writeLines(c(">ref;;genus;;species_a", "ACGTACGT"), db_file)
+    writeLines(c(
+        "#!/bin/sh",
+        "out=''",
+        "while [ \"$#\" -gt 0 ]; do",
+        "    if [ \"$1\" = \"--blast6out\" ]; then",
+        "        shift",
+        "        out=\"$1\"",
+        "    fi",
+        "    shift",
+        "done",
+        "printf 'Row1\\tref;;genus;;species_a\\t99\\n' > \"$out\"",
+        "exit 0"
+    ), fake_vsearch)
+    Sys.chmod(fake_vsearch, mode="0755")
+
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 2),
+            nrow=1,
+            dimnames=list("ACGTACGT", c("sample1", "sample2"))
+        ),
+        metadata=data.frame(sample=c("sample1", "sample2"))
+    )
+
+    processed <- process.16s(
+        abd.meta,
+        which_16s_method="vsearch",
+        vsearch_dir=fake_vsearch,
+        data_dir=tmp,
+        vsearch_16sfile=basename(db_file),
+        out_dir=out_dir,
+        error_to_file=FALSE
+    )
+
+    expect_true(file.exists(file.path(out_dir, "phylogenize-16s-asvs.fna")))
+    expect_true(file.exists(file.path(out_dir, "phylogenize-16s-vsearch.tsv")))
+    expect_equal(rownames(processed$mtx), "species_a")
+})
+
 test_that("process.16s requires an explicit 16S mapping method", {
     abd.meta <- list(
         mtx=matrix(
@@ -387,6 +436,41 @@ test_that("process.16s errors clearly when mapped samples are all zero", {
     )
 })
 
+test_that("get.appspam.results validates jplace input before parsing", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("jplace-validation-")
+    dir.create(tmp)
+    empty_jplace <- file.path(tmp, "empty.jplace")
+    writeLines(character(), empty_jplace)
+
+    expect_error(
+        get.appspam.results(
+            which_16s_method="jplace",
+            jplace_file="",
+            error_to_file=FALSE
+        ),
+        "jplace_file must be provided"
+    )
+    expect_error(
+        get.appspam.results(
+            which_16s_method="jplace",
+            jplace_file=file.path(tmp, "missing.jplace"),
+            error_to_file=FALSE
+        ),
+        "jplace file not found"
+    )
+    expect_error(
+        get.appspam.results(
+            which_16s_method="jplace",
+            jplace_file=empty_jplace,
+            error_to_file=FALSE
+        ),
+        "jplace file was empty"
+    )
+})
+
 test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
     opts <- pz.resolve.options(
         min_frac_16s=0.5,
@@ -411,16 +495,26 @@ test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
     )
 
     summed <- sum.nonunique.vsearch(vsearch, mtx, .opts=opts)
+    stats <- attr(summed, "phylogenize_16s_stats")
+    summed_mtx <- as.matrix(summed)
+    attr(summed_mtx, "phylogenize_16s_stats") <- NULL
 
     expect_equal(rownames(summed), c("target_b", "target_a"))
     expect_equal(
-        as.matrix(summed),
+        summed_mtx,
         rbind(
             target_b=c(1, 2, 3),
             target_a=c(14, 16, 18)
         ),
         ignore_attr="dimnames"
     )
+    expect_equal(stats$total_asvs, 4)
+    expect_equal(stats$mapped_asvs, 4)
+    expect_equal(stats$retained_asvs, 3)
+    expect_equal(stats$dropped_asvs, 1)
+    expect_equal(stats$retained_species, 2)
+    expect_equal(stats$total_abundance, 78)
+    expect_equal(stats$retained_abundance, 54)
 })
 
 test_that("run.vsearch validates executable and input files", {

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -50,6 +50,13 @@ test_that("run.appspam uses shared external command runner", {
     dir.create(tmp)
     capture_file <- file.path(tmp, "appspam-args.txt")
     fake_appspam <- file.path(tmp, "appspam")
+    aln_file <- file.path(tmp, "aln.fna")
+    tree_file <- file.path(tmp, "tree.nwk")
+    query_file <- file.path(tmp, "input.fna")
+    jplace_file <- file.path(tmp, "out.jplace")
+    writeLines(c(">ref", "ACGT"), aln_file)
+    writeLines("(ref:1);", tree_file)
+    writeLines(c(">Row1", "ACGT"), query_file)
     writeLines(c(
         "#!/bin/sh",
         sprintf("printf '%%s\\n' \"$@\" > %s", shQuote(capture_file)),
@@ -59,21 +66,21 @@ test_that("run.appspam uses shared external command runner", {
 
     expect_true(run.appspam(
         appspam_path=fake_appspam,
-        aln_path_16s=file.path(tmp, "aln.fna"),
-        tree_path_16s=file.path(tmp, "tree.nwk"),
-        named_asv_file=file.path(tmp, "input.fna"),
-        jplace_file=file.path(tmp, "out.jplace"),
+        aln_path_16s=aln_file,
+        tree_path_16s=tree_file,
+        named_asv_file=query_file,
+        jplace_file=jplace_file,
         ncl=3,
         error_to_file=FALSE
     ))
 
     expect_equal(
         readLines(capture_file),
-        c("-s", file.path(tmp, "aln.fna"),
-          "-t", file.path(tmp, "tree.nwk"),
-          "-q", file.path(tmp, "input.fna"),
+        c("-s", aln_file,
+          "-t", tree_file,
+          "-q", query_file,
           "--threads", "3",
-          "-o", file.path(tmp, "out.jplace"))
+          "-o", jplace_file)
     )
 
     writeLines(c("#!/bin/sh", "exit 7"), fake_appspam)
@@ -81,14 +88,137 @@ test_that("run.appspam uses shared external command runner", {
     expect_error(
         run.appspam(
             appspam_path=fake_appspam,
-            aln_path_16s=file.path(tmp, "aln.fna"),
-            tree_path_16s=file.path(tmp, "tree.nwk"),
-            named_asv_file=file.path(tmp, "input.fna"),
-            jplace_file=file.path(tmp, "out.jplace"),
+            aln_path_16s=aln_file,
+            tree_path_16s=tree_file,
+            named_asv_file=query_file,
+            jplace_file=jplace_file,
             ncl=3,
             error_to_file=FALSE
         ),
         "AppSpam failed with error code 7"
+    )
+})
+
+test_that("run.appspam validates executable, inputs, and output options", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+
+    tmp <- tempfile("appspam-validation-")
+    dir.create(tmp)
+    fake_appspam <- file.path(tmp, "appspam")
+    aln_file <- file.path(tmp, "aln.fna")
+    tree_file <- file.path(tmp, "tree.nwk")
+    query_file <- file.path(tmp, "input.fna")
+    jplace_file <- file.path(tmp, "out.jplace")
+    writeLines(c("#!/bin/sh", "exit 0"), fake_appspam)
+    writeLines(c(">ref", "ACGT"), aln_file)
+    writeLines("(ref:1);", tree_file)
+    writeLines(c(">Row1", "ACGT"), query_file)
+
+    expect_error(
+        run.appspam(
+            appspam_path=file.path(tmp, "missing-appspam"),
+            aln_path_16s=aln_file,
+            tree_path_16s=tree_file,
+            named_asv_file=query_file,
+            jplace_file=jplace_file,
+            ncl=1,
+            error_to_file=FALSE
+        ),
+        "AppSpam executable not found"
+    )
+
+    expect_error(
+        run.appspam(
+            appspam_path=fake_appspam,
+            aln_path_16s=aln_file,
+            tree_path_16s=tree_file,
+            named_asv_file=query_file,
+            jplace_file=jplace_file,
+            ncl=1,
+            error_to_file=FALSE
+        ),
+        "AppSpam executable is not runnable"
+    )
+
+    Sys.chmod(fake_appspam, mode="0755")
+
+    expect_error(
+        run.appspam(
+            appspam_path=fake_appspam,
+            aln_path_16s=file.path(tmp, "missing-aln.fna"),
+            tree_path_16s=tree_file,
+            named_asv_file=query_file,
+            jplace_file=jplace_file,
+            ncl=1,
+            error_to_file=FALSE
+        ),
+        "16S alignment file not found"
+    )
+
+    expect_error(
+        run.appspam(
+            appspam_path=fake_appspam,
+            aln_path_16s=aln_file,
+            tree_path_16s=file.path(tmp, "missing-tree.nwk"),
+            named_asv_file=query_file,
+            jplace_file=jplace_file,
+            ncl=1,
+            error_to_file=FALSE
+        ),
+        "16S tree file not found"
+    )
+
+    expect_error(
+        run.appspam(
+            appspam_path=fake_appspam,
+            aln_path_16s=aln_file,
+            tree_path_16s=tree_file,
+            named_asv_file=file.path(tmp, "missing-input.fna"),
+            jplace_file=jplace_file,
+            ncl=1,
+            error_to_file=FALSE
+        ),
+        "16S query FASTA not found"
+    )
+
+    expect_error(
+        run.appspam(
+            appspam_path=fake_appspam,
+            aln_path_16s=aln_file,
+            tree_path_16s=tree_file,
+            named_asv_file=query_file,
+            jplace_file="",
+            ncl=1,
+            error_to_file=FALSE
+        ),
+        "jplace_file must be provided"
+    )
+
+    expect_error(
+        run.appspam(
+            appspam_path=fake_appspam,
+            aln_path_16s=aln_file,
+            tree_path_16s=tree_file,
+            named_asv_file=query_file,
+            jplace_file=file.path(tmp, "missing-dir", "out.jplace"),
+            ncl=1,
+            error_to_file=FALSE
+        ),
+        "AppSpam output directory not found"
+    )
+
+    expect_error(
+        run.appspam(
+            appspam_path=fake_appspam,
+            aln_path_16s=aln_file,
+            tree_path_16s=tree_file,
+            named_asv_file=query_file,
+            jplace_file=jplace_file,
+            ncl=1.5,
+            error_to_file=FALSE
+        ),
+        "ncl must be a positive integer"
     )
 })
 

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -271,7 +271,7 @@ test_that("16S helpers can use resolved options without global mutation", {
     expect_equal(pz.options("min_frac_16s"), 1)
 })
 
-test_that("sum.nonunique.vsearch aggregates duplicate hits in target order", {
+test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
     opts <- pz.resolve.options(
         min_frac_16s=0.5,
         error_to_file=FALSE
@@ -296,15 +296,12 @@ test_that("sum.nonunique.vsearch aggregates duplicate hits in target order", {
 
     summed <- sum.nonunique.vsearch(vsearch, mtx, .opts=opts)
 
-    expect_equal(rownames(summed), c("target_b", "target_a",
-                                     "target_c", "target_d"))
+    expect_equal(rownames(summed), c("target_b", "target_a"))
     expect_equal(
         as.matrix(summed),
         rbind(
             target_b=c(1, 2, 3),
-            target_a=c(14, 16, 18),
-            target_c=c(7, 8, 9),
-            target_d=c(7, 8, 9)
+            target_a=c(14, 16, 18)
         ),
         ignore_attr="dimnames"
     )

--- a/package/phylogenize/tests/testthat/test-process-16S.R
+++ b/package/phylogenize/tests/testthat/test-process-16S.R
@@ -291,6 +291,102 @@ test_that("process.16s requires an explicit 16S mapping method", {
     )
 })
 
+test_that("process.16s errors clearly when no ASVs are retained", {
+    tmp <- tempfile("vsearch-no-asvs-")
+    dir.create(tmp)
+    fake_vsearch <- file.path(tmp, "vsearch")
+    db_file <- file.path(tmp, "db.fna")
+    query_file <- file.path(tmp, "input.fna")
+    hits_file <- file.path(tmp, "hits.tsv")
+    writeLines(c(">ref;;genus;;species_a", "ACGTACGT"), db_file)
+    writeLines(c(
+        "#!/bin/sh",
+        "out=''",
+        "while [ \"$#\" -gt 0 ]; do",
+        "    if [ \"$1\" = \"--blast6out\" ]; then",
+        "        shift",
+        "        out=\"$1\"",
+        "    fi",
+        "    shift",
+        "done",
+        "printf 'Row1\\tref;;genus;;species_a\\t99\\nRow1\\tref;;genus;;species_b\\t99\\n' > \"$out\"",
+        "exit 0"
+    ), fake_vsearch)
+    Sys.chmod(fake_vsearch, mode="0755")
+
+    abd.meta <- list(
+        mtx=matrix(
+            c(1, 2),
+            nrow=1,
+            dimnames=list("ACGTACGT", c("sample1", "sample2"))
+        ),
+        metadata=data.frame(sample=c("sample1", "sample2"))
+    )
+
+    expect_error(
+        process.16s(
+            abd.meta,
+            which_16s_method="vsearch",
+            vsearch_dir=fake_vsearch,
+            data_dir=tmp,
+            vsearch_16sfile=basename(db_file),
+            named_asv_file=query_file,
+            vsearch_outfile=hits_file,
+            min_frac_16s=0.5,
+            error_to_file=FALSE
+        ),
+        "No 16S ASVs were retained after mapping"
+    )
+})
+
+test_that("process.16s errors clearly when mapped samples are all zero", {
+    tmp <- tempfile("vsearch-zero-samples-")
+    dir.create(tmp)
+    fake_vsearch <- file.path(tmp, "vsearch")
+    db_file <- file.path(tmp, "db.fna")
+    query_file <- file.path(tmp, "input.fna")
+    hits_file <- file.path(tmp, "hits.tsv")
+    writeLines(c(">ref;;genus;;species_a", "ACGTACGT"), db_file)
+    writeLines(c(
+        "#!/bin/sh",
+        "out=''",
+        "while [ \"$#\" -gt 0 ]; do",
+        "    if [ \"$1\" = \"--blast6out\" ]; then",
+        "        shift",
+        "        out=\"$1\"",
+        "    fi",
+        "    shift",
+        "done",
+        "printf 'Row1\\tref;;genus;;species_a\\t99\\n' > \"$out\"",
+        "exit 0"
+    ), fake_vsearch)
+    Sys.chmod(fake_vsearch, mode="0755")
+
+    abd.meta <- list(
+        mtx=matrix(
+            c(0, 0),
+            nrow=1,
+            dimnames=list("ACGTACGT", c("sample1", "sample2"))
+        ),
+        metadata=data.frame(sample=c("sample1", "sample2"))
+    )
+
+    expect_error(
+        process.16s(
+            abd.meta,
+            which_16s_method="vsearch",
+            vsearch_dir=fake_vsearch,
+            data_dir=tmp,
+            vsearch_16sfile=basename(db_file),
+            named_asv_file=query_file,
+            vsearch_outfile=hits_file,
+            min_frac_16s=1,
+            error_to_file=FALSE
+        ),
+        "No samples retained nonzero abundance after 16S mapping"
+    )
+})
+
 test_that("sum.nonunique.vsearch drops ambiguous ties and aggregates targets", {
     opts <- pz.resolve.options(
         min_frac_16s=0.5,

--- a/package/phylogenize/tests/testthat/test-report-functions.R
+++ b/package/phylogenize/tests/testthat/test-report-functions.R
@@ -73,3 +73,17 @@ test_that("add.plotly.tree.branches appends branch traces to interactive trees",
     expect_s3_class(p, "plotly")
     expect_true(length(p$x$attrs) > 0 || length(p$x$data) > 0)
 })
+
+test_that("get_rel_pd handles singleton gene subtrees", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    opts <- pz.resolve.options(
+        gene_min_frac=0.5,
+        verbosity=0,
+        error_to_file=FALSE
+    )
+    tr <- ape::read.tree(text="((s1:1,s2:1):1,s3:1);")
+    gene <- c(s1=1, s2=0, s3=0)
+
+    expect_equal(get_rel_pd(gene, tr, flip_sign=FALSE, .opts=opts), 0)
+})

--- a/package/phylogenize/tests/testthat/test-significance-helpers.R
+++ b/package/phylogenize/tests/testthat/test-significance-helpers.R
@@ -307,3 +307,35 @@ test_that("negative-only significant taxa are retained after thresholding", {
     expect_equal(out$neg.sig.thresh$TaxonNeg, "g_neg")
     expect_equal(out$phy.with.sigs, "TaxonNeg")
 })
+
+test_that("significant gene thresholding uses binary gene_min_frac calls", {
+    old_opts <- pz.options()
+    on.exit(do.call(pz.options, old_opts), add=TRUE)
+    opts <- pz.resolve.options(
+        minimum=2,
+        gene_min_frac=0.5,
+        verbosity=0,
+        error_to_file=FALSE
+    )
+    pz.db <- list(
+        trees=list(TaxonA=ape::read.tree(text="(s1:1,s2:1,s3:1,s4:1);")),
+        gene.presence=list(
+            TaxonA=Matrix::Matrix(
+                matrix(
+                    c(1.0, 0.3, 0.3, 0.4,
+                      1.0, 1.0, 0.0, 0.0),
+                    nrow=2,
+                    byrow=TRUE,
+                    dimnames=list(c("g_fractional_singleton", "g_binary_ok"),
+                                  paste0("s", 1:4))
+                ),
+                sparse=TRUE
+            )
+        )
+    )
+    pos.sig <- list(TaxonA=c("g_fractional_singleton", "g_binary_ok"))
+
+    filtered <- threshold.pos.sigs(pz.db, "TaxonA", pos.sig, .opts=opts)
+
+    expect_equal(filtered$TaxonA, "g_binary_ok")
+})


### PR DESCRIPTION
  This PR updates phylogenize to v2.0.4, improves 16S import and AppSpam/jplace workflow validation with clearer diagnostics and audit outputs, documents custom database index requirements,
  hardens q-value correction and report rendering edge cases, and adds regression tests for the new 16S and singleton-subtree behavior.

  Commit-level descriptions:
  - 5ddce4f: Bumps the package version to v2.0.3.
  - db03544: Documents the custom database index format in the README.
  - fd9c29d: Handles invalid p-values safely during q-value correction.
  - a4c15af: Resolves the DESCRIPTION version conflict.
  - 8baff7d: Validates AppSpam inputs before execution.
  - 49f3b09: Bumps the package version to v2.0.4.
  - 91b0481: Adds an active 16S import workflow test.
  - b16e072: Drops ambiguous 16S ASV assignments.
  - 95f17a9: Requires users to explicitly choose the 16S mapping method.
  - 591bb24: Fails clearly when 16S mapping returns no results.
  - fab09be: Improves 16S workflow diagnostics and path handling.
  - 46b4c8d: Writes an audit table for 16S assignments.
  - a39ef36: Adds a jplace-based 16S workflow test.
  - 190277e: Fixes report crashes from singleton gene subtrees and aligns gene thresholding before rendering.